### PR TITLE
Adding survey_override option for Roku

### DIFF
--- a/roku_tar_choice_card_config_params.md
+++ b/roku_tar_choice_card_config_params.md
@@ -38,6 +38,7 @@ The following lists and describes each supported parameter for TruexAdRenderer (
 | ctvw | 0 | width of the visual countdown timer bar. |
 | ctvh | 0 | height of the visual countdown timer bar. |
 | ctvc | 0x555555ff | color for visual countdown timer bar. |
+| survey_override | n/a | object that represent a survey card. When TAR receive a survey, it will try to override the current choice card with this object. The format of this card is same as a normal choice card. |
 
 ---
 


### PR DESCRIPTION
Update roku_tar_choice_card_config_params.md to include `survey_override` for Roku.
See this PR: https://github.com/socialvibe/TruexAdRenderer-Roku/pull/332
Also see this example:https://github.com/socialvibe/southback/commit/d9bf32c72841bd550bbd6e77bc543d29fa2d8241