### PR TITLE
Task/ctv 3167 update bluescript doc to latest truth

### DIFF
--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -339,7 +339,10 @@ now recommended, as shown with the examples below:
 { "host" : "debugLog", "value" : {"local":  "now.time"} },           // 1631316792480, e.g. millis since Jan 1, 1970
 
 {"host": "assign", "local": "now", "value":  {"date":  1631316792480}}, // from timestamp
-{"host": "assign", "local": "nextWeek", "value": {"+": [{"local": "now.time"}, {"*": [7, 24, 60, 60, 1000]}]}}, // next week
+{
+  "host": "assign", "local": "nextWeek", 
+  "value": {"date": {"+": [{"local": "now.time"}, {"*": [7, 24, 60, 60, 1000]}]}} // next week
+},
 
 { "host": "assign", "local": "yearStart", "value":  {"date": {"year": 2021}} },
 { "host" : "debugLog", "value" : {"local": "yearStart.month"} },   // 1

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -250,7 +250,7 @@ For example:
  { "host" : "assign", "local": "localValue.field_2.subField.2", "value":  4},
 ```
 
-### Expressions.
+### Expressions
 
 Expressions are used to compare values, perform arithmetic operations, logical operations, and perform functions that return value (random, for example), given an array of `values` as input.
 
@@ -280,7 +280,7 @@ now recommended, as shown with the examples below:
 #### String Operations
 ```json
  { "host" : "debugLog", "value" : {"+": ["full name: ", "John", " ", "Doe"] } }, // full name: John Doe
- { "host" : "debugLog", "value" : {"replace": ["This is badass.", "badass", "awesome"]}}, // This is awesome 
+ { "host" : "debugLog", "value" : {"replace": ["This is badass", "badass", "awesome"]}}, // This is awesome 
 ```
 
 #### Comparison Operations
@@ -312,7 +312,7 @@ now recommended, as shown with the examples below:
     }
   }
 },
-{"host": "debugLog", "value": {"local": "objectValue.that.a"}},
+{"host": "debugLog", "value": {"key": "objectValue.that.a"}},
 {"host": "assign", "key": "objectValue.that.b", "value": true},
         
 {"host": "debugLog", "value": {"arg": "x"}}, // error if "x" not supplied when function invoked

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -418,7 +418,7 @@ For example:
 }
 ```
 
-#### Additional Rectangle Properties
+Additional Rectangle Properties:
 
 Property | Default | Description
 --- | --- | ---
@@ -445,7 +445,7 @@ For example:
 }
 ```
 
-#### Additional Image Properties
+Additional Image Properties:
 
 Property | Default | Description
 --- | --- | ---
@@ -474,7 +474,7 @@ For example:
 }
 ```
 
-#### Additional Video Properties
+Additional Video Properties:
 
 Property | Default | Description
 --- | --- | ---
@@ -520,7 +520,7 @@ For example:
 }
 ```
 
-#### Additional Text Properties
+Additional Text Properties:
 
 Property | Default | Description
 --- | --- | ---
@@ -563,7 +563,7 @@ For example:
 }
 ```
 
-#### Additional Button Properties
+Additional Button Properties:
 
 Property | Default | Description
 --- | --- | ---
@@ -601,9 +601,7 @@ For example:
 }
 ```
 
-#### Additional Audio Properties
-
-Note: visual properties are not relevant for the Audio element, e.g. x, y, width, height, opacity. 
+Additional Audio Properties:
 
 Property | Default | Description
 --- | --- | ---
@@ -613,6 +611,7 @@ autoplay | true | If set to true, the audio will be automatically started on car
 global | false | If true, audio sticks/continues playing across step card transitions.
 
 NOTES:
+* Visual properties are not relevant for the Audio element, e.g. x, y, width, height, opacity.
 * On Roku, only a single Media node may be actively playing or buffering media at a given time. This means that it is not possible to have multiple inline videos playing concurrently or a background / ambient video with inline window windows on top. This also precludes the use of background audio playing together with a video. Any additional stream started after the first one will fail silently.
 * For the MP3 format. On the PlayStation 5 and some other platforms, MP3 is not supported. BlueScript engine will try to get the MP4 version (same location, same name) of the given audio instead. Asset Uploader in True Exchange is encoding that MP4 file automatically. Be sure to include a MP4 version of your audio file if you cannot use the Asset Uploader.
 
@@ -644,7 +643,7 @@ For example:
 }
 ```
 
-#### Additional Button Properties
+Additional Button Properties:
 
 Property | Default | Description
 --- | --- | ---

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -140,27 +140,37 @@ For example:
 
 A step's "functions" property contains all reusable functions, keyed by function name, that can be called from other event action execution, expressions, and even other functions.
 
-One uses the `invoke` behavior action or expression to execute functions. Arguments are passed by name, and are referred to with the function via the `arg` expression.
+One uses the `invoke` behavior action or expression to execute functions. 
+
+Arguments are passed by name, and are referred to with the function via the `arg` expression.
+
+Argument values are passed using reference semantics, matching JavaScript rules, thus objects and arrays are shared allowing for modification of subfields or elements on the shared item.
+
+Within a function, referring to arguments not in the invocation causes a script error, unless a default value is provided in the `arg` expression.
 
 The `return` host action can be used to return from the function immediately.
 
 Local variable values can be assigned via the `local` assign action. Such variables exist only during the current invocation's execution.
 
-<summary>For example:</summary>
-
+For example:
 ```json
 {
   "elements": [...],
   "functions": {
     "testFunction": [
-      {"host": "assign", "local": "v", "value": {"arg": "x"}},
-      {"host": "return", "value": {"+": [{"local": "v"}, {"local": "v"}]}}
+       {"host": "assign", "local": "result", "value": {"+": [{"arg": "x"}, {"arg":  "x"}]}},
+       {"host": "assign", "local": "sharedObj", "value": {"arg": "sharedArg", "default": {}}},
+       {"host": "assign", "local": "sharedObj.result", "value": {"local": "result"}},
+       {"host": "return", "value": {"local": "result"}}
     ]
   },
   "behaviors": {
     "testButton": {
       "appear": [
-        {"host": "invoke", "function": "testFunction", "args": {"x": 123}},
+        {
+           "host": "invoke", "function": "testFunction", 
+           "args": {"x": 123, "sharedArg": {"result": "TBD"}}
+        },
         {"host": "debugLog", "value": {"invoke": "testFunction", "args": {"x": 123}}}
       ]
     }

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -14,6 +14,13 @@ _rev. 2021-09-10
    1. [Literal Values](#literal-values)
    1. [Stored Values](#stored-values)
    1. [Expressions](#expressions)
+      1. [Arithmetic Operations](#arithmetic-operations)
+      1. [String Operations](#string-operations)
+      1. [Comparison Operations](#comparison-operations)
+      1. [Variable References](#variable-references)
+      1. [Date Expressions](#date-expressions)
+      1. [Misc Expressions](#misc-expressions)
+      1. [Expression Composition](#expression-composition)
 1. [BlueScript Elements](#bluescript-element-reference)
    1. [Rectangle](#rectangle)
    1. [Image](#image)
@@ -291,21 +298,6 @@ now recommended, as shown with the examples below:
 { "host" : "debugLog", "value" : {"!": true } },              // false
 ```
 
-#### Misc Expressions
-```json
-{ "host" : "debugLog", "value" : {"element": "button1", "attribute": "image_url"} },
-{ "host" : "debugLog", "value" : {"random": 10 } },                // random 0 to 9, excluding 10
-{ "host" : "assign", "value" : {"literal": {"random": 10}} }, // {"random": 10}, i.e. unevaluated expression
-{ "host" : "debugLog", "value" : {"length": ["abcde"] } },           // 5
-{ "host" : "debugLog", "value" : {"length": "abcde" } },           // single arg convenience
-{ "host" : "debugLog", "value" : {"length": [["a", "b", "c"]] } }, // 3 ; note array args require explicit array wrapper
-{ "host" : "debugLog", "value" : {"toFixed": [3.1415, 3]} },       // 3.142
-{ "host" : "debugLog", "value" : {"toTrimFixed": [2.000001, 4]} }, // 2
-{ "host" : "debugLog", "value" : {"zeroFill": [123, 5]} },         // 00123
-{ "host" : "debugLog", "value" : {"formatMinutesSeconds": 3599} },      // "59:59"
-{ "host" : "debugLog", "value" : {"formatHoursMinutesSeconds": 3599} }, // "0:59:59"
-```
-
 #### Variable References
 ```json
 {"host": "assign", "key": "globalVar", "value": 123},
@@ -360,6 +352,21 @@ now recommended, as shown with the examples below:
 { "host": "assign", "local": "yearMo", "value":  {"date": {"year": 1999, "month": 12}} },
 { "host" : "debugLog", "value" : {"local": "yearStart.month"} },   // 12
 { "host" : "debugLog", "value" : {"local": "yearStart.day"} },     // 1
+```
+
+#### Misc Expressions
+```json
+{ "host" : "debugLog", "value" : {"element": "button1", "attribute": "image_url"} },
+{ "host" : "debugLog", "value" : {"random": 10 } },                // random 0 to 9, excluding 10
+{ "host" : "assign", "value" : {"literal": {"random": 10}} }, // {"random": 10}, i.e. unevaluated expression
+{ "host" : "debugLog", "value" : {"length": ["abcde"] } },           // 5
+{ "host" : "debugLog", "value" : {"length": "abcde" } },           // single arg convenience
+{ "host" : "debugLog", "value" : {"length": [["a", "b", "c"]] } }, // 3 ; note array args require explicit array wrapper
+{ "host" : "debugLog", "value" : {"toFixed": [3.1415, 3]} },       // 3.142
+{ "host" : "debugLog", "value" : {"toTrimFixed": [2.000001, 4]} }, // 2
+{ "host" : "debugLog", "value" : {"zeroFill": [123, 5]} },         // 00123
+{ "host" : "debugLog", "value" : {"formatMinutesSeconds": 3599} },      // "59:59"
+{ "host" : "debugLog", "value" : {"formatHoursMinutesSeconds": 3599} }, // "0:59:59"
 ```
 
 #### Expression Composition

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -11,6 +11,9 @@ _rev. 2021-09-10
       1. [Functions](#functions)
    1. [Examples](#examples)
 1. [BlueScript Values and Expressions](#bluescript-values-and-expressions)
+   1. [Literal Values](#literal-values)
+   1. [Stored Values](#stored-values)
+   1. [Expressions](#expressions)
 1. [BlueScript Elements](#bluescript-element-reference)
    1. [Rectangle](#rectangle)
    1. [Image](#image)
@@ -249,74 +252,121 @@ Expressions are used to compare values, perform arithmetic operations, logical o
 { "host" : "debugLog", "value" : {"operation": "+", "values": [123, 123] } }, 
 ```
 This form is still supported for backwards compatibility so as not to break existing ads. A simplified form is
-now recommended, as shown below.
+now recommended, as shown with the examples below:
 
-#### Arithmetic Operations Example
+#### Arithmetic Operations
 ```json
- { "host" : "debugLog", "value" : {"+": [123, 123] } },
- { "host" : "debugLog", "value" : {"+": [1, 2, 3] } },
- { "host" : "debugLog","value" : {"+": [1,  {"*": [2, 3] } ] } },
+{ "host" : "debugLog", "value" : {"+": [123, 123] } }, // 246
+{ "host" : "debugLog", "value" : {"+": [1, 2, 3] } }, // 6
+{ "host" : "debugLog", "value" : {"-": [10, 5] } },   // 5
+{ "host" : "debugLog", "value" : {"*": [2, 4, 3] } }, // 24
+{ "host" : "debugLog", "value" : {"/": [10, 2] } },   // 5
+{ "host" : "debugLog", "value" : {"%": [17, 10] } },  // 7
+{ "host" : "debugLog", "value" : {"floor": 2.3 } },   // 2
+{ "host" : "debugLog", "value" : {"ceil": 2.3 } },    // 3
+{ "host" : "debugLog", "value" : {"round": 2 } },     // 2
+{ "host" : "debugLog", "value" : {"round": 2.3 } },   // 2
+{ "host" : "debugLog", "value" : {"round": 2.5 } },   // 3
+{ "host" : "debugLog", "value" : {"round": 2.8 } },   // 3
 ```
 
-#### String Operations Example
+#### String Operations
 ```json
- { "host" : "debugLog", "value" : {"+": ["string", 123] } },
- { "host" : "debugLog", "value" : {"replace": ["This is a badass.", "badass", "awesome"]}},
+ { "host" : "debugLog", "value" : {"+": ["full name: ", "John", " ", "Doe"] } }, // full name: John Doe
+ { "host" : "debugLog", "value" : {"replace": ["This is badass.", "badass", "awesome"]}}, // This is awesome 
 ```
 
-#### Comparison Operations Example
+#### Comparison Operations
 ```json
- { "host" : "debugLog", "value" : {"&&": [true, false] } },
- { "host" : "debugLog", "value" : {"||": [true, false] } },
- { "host" : "debugLog", "value" : {"!": true } },
+{ "host" : "debugLog", "value" : {"==": [1, 1] } },           // true
+{ "host" : "debugLog", "value" : {"==": ["this", "that"] } }, // false
+{ "host" : "debugLog", "value" : {"!=": [1, 1] } },           // false
+{ "host" : "debugLog", "value" : {"!=": ["this", "that"] } }, // true
+{ "host" : "debugLog", "value" : {"<": [2, 3] } },           // true
+{ "host" : "debugLog", "value" : {"<=": [3, 3] } },           // true
+{ "host" : "debugLog", "value" : {">": [5, 4] } },           // true
+{ "host" : "debugLog", "value" : {">=": [5, 5] } },           // true
+{ "host" : "debugLog", "value" : {"&&": [true, false] } },    // false
+{ "host" : "debugLog", "value" : {"||": [true, false] } },    // true
+{ "host" : "debugLog", "value" : {"!": true } },              // false
 ```
 
-#### Misc Operations Example
+#### Misc Expressions
 ```json
- { "host" : "debugLog", "value" : {"random": 10 } },
+{ "host" : "debugLog", "value" : {"element": "button1", "attribute": "image_url"} },
+{ "host" : "debugLog", "value" : {"random": 10 } },                // random 0 to 9, excluding 10
+{ "host" : "assign", "value" : {"literal": {"random": 10}} }, // {"random": 10}, i.e. unevaluated expression
+{ "host" : "debugLog", "value" : {"length": ["abcde"] } },           // 5
+{ "host" : "debugLog", "value" : {"length": "abcde" } },           // single arg convenience
+{ "host" : "debugLog", "value" : {"length": [["a", "b", "c"]] } }, // 3 ; note array args require explicit array wrapper
+{ "host" : "debugLog", "value" : {"toFixed": [3.1415, 3]} },       // 3.142
+{ "host" : "debugLog", "value" : {"toTrimFixed": [2.000001, 4]} }, // 2
+{ "host" : "debugLog", "value" : {"zeroFill": [123, 5]} },         // 00123
+{ "host" : "debugLog", "value" : {"formatMinutesSeconds": 3599} },      // "59:59"
+{ "host" : "debugLog", "value" : {"formatHoursMinutesSeconds": 3599} }, // "0:59:59"
 ```
 
-#### Operation Expression format:
+#### Variable References
 ```json
-{"<operation>": <values>}
+{"host": "assign", "key": "globalVar", "value": 123},
+{"host": "debugLog", "value": {"key": "globalVar"}},
+{"host": "assign", "key": "localVar", "value": "something else"},
+{"host": "debugLog", "value": {"local": "localVar"}},
+{
+  "host": "assign", "key": "objectValue", "value": {
+    "literal": {
+      "this": 123,
+      "that": {"a": true, "b": false}
+    }
+  }
+},
+{"host": "debugLog", "value": {"local": "objectValue.that.a"}},
+{"host": "assign", "key": "objectValue.that.b", "value": true},
+        
+{"host": "debugLog", "value": {"arg": "x"}}, // error if "x" not supplied when function invoked
+{"host": "debugLog", "value": {"arg": "x", "default": 0}}, // default is used if not supplied
 ```
 
-Where we have:
-operation | One of the operator strings from the Operator table below.
-values | An array of simple values or expressions, or a single value object as input it the operation takes a single parameter.
+#### Date Expressions
+```json
+{"host": "assign", "local": "now", "value":  {"date":  "now"}}, // from clock
+{"host": "assign", "local": "now", "value":  {
+   "date": {
+      "year": 2021, "month":  9, "day": 10, "hours": 16, "minutes": 33, "seconds": 12, "milliseconds": 480
+   }
+}},
+{ "host" : "debugLog", "value" : {"local":  "now.year"} },           // 2021
+{ "host" : "debugLog", "value" : {"local":  "now.month"} },          // 9
+{ "host" : "debugLog", "value" : {"local":  "now.day"} },            // 10
+{ "host" : "debugLog", "value" : {"local":  "now.hours"} },          // 16
+{ "host" : "debugLog", "value" : {"local":  "now.minutes"} },        // 33
+{ "host" : "debugLog", "value" : {"local":  "now.seconds"} },        // 12
+{ "host" : "debugLog", "value" : {"local":  "now.milliseconds"} },   // 480
+{ "host" : "debugLog", "value" : {"local":  "now.weekDay"} },        // 5
+{ "host" : "debugLog", "value" : {"local":  "now.timezoneOffset"} }, // 480
+{ "host" : "debugLog", "value" : {"local":  "now.time"} },           // 1631316792480, e.g. millis since Jan 1, 1970
 
-##### Operation
-Operator | Description | Number of input | Input type | Example | Means
--------  | ----------- | --------------- | ---------- | ------- | -----
-\+ | Addition | >=2 | Number | `{"+": [123, 123] }` | 123 + 123
-\+ | Concatenate String | >=2 | String | `{"+": ["hello", "_world"] }` | "hello" + "\_world"
-\- | Subtraction | >=2 | Number | `{"-": [123, 1, 23] }` | 123 - 1 - 23
-\* | Multiplication | >=2 | Number | `{"*": [123, 2] }` | 123 \* 2
-/ | Division | >=2 | Number | `{"/": [123, 2] }` | 123 / 2
-% | Modulus (division remainder) | 2 | Number | `{"%": [123, 2] }` | 123 % 2
-== | Equal to | 2 | String, Number, or Boolean | `{"==": [123, 2] }` | 123 == 2
-!= | Not equal | 2 | String, Number, or Boolean | `{"!=": [123, 2] }` | 123 != 2
-\> | Greater than | 2 | Number | `{">": [123, 2] }` | 123 > 2
-< | Less than | 2 | Number | `{"<": [123, 2] }` | 123 < 2
-\>= | Greater than or equal to | 2 | Number | `{">=": [123, 2] }` | 123 >= 2
-<= | Less than or equal to | 2 | Number | `{"<=": [123, 2] }` | 123 <= 2
-&& | And | 2 | Boolean | `{"&&": [true, false] }` | true && false --> (false)
-&vert;&vert; | Or | 2 | Boolean | {"&vert;&vert;": [true, false] } | true &vert;&vert; false --> (true)
-! | Not | 1 | Boolean | `{"!": true }` | !true --> (false)
-replace | String replace | 3 | String | `{"replace": ["Original String to Replace", "Replace", "Modify"] }` | "Original String to Replace".replace("Replace", "Modify")
-random | Random number | 1 | Number | `{"random": 10 }` | random(10)
-length | Length | 1 | Natural | `{"length": "abcde" }` | "abcde".length
-length | Length | 1 | Natural | `{"length": [[1, 2, 3]] }` | [1,2,3].length
-max | Maximum | >=2 | Number | `{"max": [1, 2] }` | max(1, 2)
-min | Minimum | >=2 | Number | `{"min": [1, 2] }` | min(1, 2)
-floor | Floor | 1 | Number | `{"floor": 1.5 }` | Math.floor(1.5)
-ceil | Ceiling | 1 | Number | `{"ceil": 1.5 }` | Math.ceil(1.5)
-round | Round | 1 | Number | `{"round": 1.5 }` | Math.round(1.5)
-toFixed | Shows specified # of digits after the decimal point | 2 | Number | `{"toFixed": [3.1415, 3]}` returns `"3.142"` | (3.1415).toFixed(3)
-toTrimFixed | Like {toFixed}, but also strips trailing zeroes | 2 | Number | `{"toTrimFixed": [2.000001, 4]}` returns `"2"` | Number((2.000001).toFixed(4)).toString()
-zeroFill | Fill number with leading 0s | 2 | Number | `{"zeroFill": [123, 5]}`  returns `"00123"` | "00" + (123).toString()
-formatMinutesSeconds | Format seconds as `MM:SS`, or `H:MM:SS` if over an hour | 1 | Number | `{"formatMinutesSeconds": 3599}` returns `"59:59"` | -
-formatHoursMinutesSeconds | Format seconds as `H:MM:SS` | 1 | Number | `{"formatMinutesSeconds": 3599}` returns `"0:59:59"` | -
+{"host": "assign", "local": "now", "value":  {"date":  1631316792480}}, // from timestamp
+{"host": "assign", "local": "nextWeek", "value": {"+": [{"local": "now.time"}, {"*": [7, 24, 60, 60, 1000]}}, // next week
+
+{ "host": "assign", "local": "yearStart", "value":  {"date": {"year": 2021}} },
+{ "host" : "debugLog", "value" : {"local": "yearStart.month"} },   // 1
+{ "host" : "debugLog", "value" : {"local": "yearStart.day"} },     // 1
+{ "host" : "debugLog", "value" : {"local": "yearStart.hours"} },   // 0
+{ "host" : "debugLog", "value" : {"local": "yearStart.minutes"} }, // 0
+{ "host" : "debugLog", "value" : {"local": "yearStart.seconds"} }, // 0
+{ "host" : "debugLog", "value" : {"local": "yearStart.time"} },    // 1612166400000
+
+{ "host": "assign", "local": "yearMo", "value":  {"date": {"year": 1999, "month": 12}} },
+{ "host" : "debugLog", "value" : {"local": "yearStart.month"} },   // 12
+{ "host" : "debugLog", "value" : {"local": "yearStart.day"} },     // 1
+```
+
+#### Expression Composition
+```json
+{ "host" : "debugLog", "value" : {"+": [1, {"*": [2, {"local": "testValue"}] } ] } }
+```
+
 ---
 
 ## BlueScript Element Reference

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -765,7 +765,7 @@ videoDidExitFullscreen | Triggered when video is set back to its original size.
 This section details the behavior actions that can be scripted. Actions are invoked when Events occur, 
 or when a BlueScript function is invoked.
 
-##### (1) - `allDoneButtonPushed`
+##### `allDoneButtonPushed`
 
 Triggers the "Return to Content" button, exiting the ad flow for a completed ad.
 
@@ -774,8 +774,6 @@ Triggers the "Return to Content" button, exiting the ad flow for a completed ad.
 [Deprecated: "step stacking" is no longer upported, not even available on HTML5. Use explicit `replaceStep` actions instead.]
 
 Navigates to a different BlueScript step, pushing the new step onto the navigational stack. A viewer is able to get back to the previous step using the BACK key or equivalent.
-
-###### Parameters
 
 Parameter | Description
 --- | ---

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -939,7 +939,7 @@ For example:
 Parameter | Description
 --- | ---
 url | The server/file location.
-assignResponseTo | take a json with a `key` or `local` entry, which points to variable that the returned string/json will be assigned to.
+assignResponseTo | takes a variable reference with a `key` or `local` entry, which points to variable that the returned string/json will be assigned to.
 responseAsJson | (optional, default: false) will try to parse the return as JSON before save.
 onload | An array of Behavior Actions to be executed on call successed.
 onerror | An array of Behavior Actions to be executed on call failed.

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -517,7 +517,7 @@ On Roku, only a single Media node may be actively playing or buffering media at 
 
 #### Video Behavior Actions
 
-##### (1) - `playVideo`
+##### `playVideo`
 
 Starts or resumes playback (for a paused video) for the target video.
 
@@ -525,7 +525,7 @@ Parameter | Description
 --- | ---
 target | Name of the video to play.
 
-##### (2) - `pauseVideo`
+##### `pauseVideo`
 
 Pauses playback for the target video.
 
@@ -533,7 +533,7 @@ Parameter | Description
 --- | ---
 target | Name of the video to pause.
 
-##### (3) - `resetVideo`
+##### `resetVideo`
 
 Resets playback for the target video by setting the play head to the beginning.
 
@@ -541,7 +541,7 @@ Parameter | Description
 --- | ---
 target | Name of the video to reset.
 
-##### (4) - `stopVideo`
+##### `stopVideo`
 
 Stops playback for the target video.
 
@@ -668,19 +668,19 @@ Note on MP3 format. On PlayStation, and some other platforms, MP3 is not support
 
 #### Audio Behavior Actions
 
-##### (1) - `playActiveAudio`
+##### `playActiveAudio`
 
 Starts or resumes playback (if currently paused) for the active audio element.
 
-##### (2) - `pauseActiveAudio`
+##### `pauseActiveAudio`
 
 Pauses playback for the active audio element.
 
-##### (3) - `resetActiveAudio`
+##### `resetActiveAudio`
 
 Resets playback for the active audio element by setting the play head to the beginning.
 
-##### (4) - `stopActiveAudio`
+##### `stopActiveAudio`
 
 Stops playback for the active audio element.
 
@@ -755,7 +755,7 @@ or when a BlueScript function is invoked.
 
 Triggers the "Return to Content" button, exiting the ad flow for a completed ad.
 
-##### (2) - `showStep`
+##### `showStep`
 
 [Deprecated: "step stacking" is no longer upported, not even available on HTML5. Use explicit `replaceStep` actions instead.]
 
@@ -765,7 +765,7 @@ Parameter | Description
 --- | ---
 cardName | Name of the step to transition to, as defined in the top level list of BlueScript steps.
 
-##### (3) - `replaceStep`
+##### `replaceStep`
 
 Navigates to a different BlueScript step, replacing the current step being displayed.
 
@@ -773,12 +773,12 @@ Parameter | Description
 --- | ---
 cardName | Name of the step to transition to, as defined in the top level list of BlueScript steps.
 
-##### (4) - `resetFocus`
+##### `resetFocus`
 
 Re-initializes the focus handler and ensures a default control is focused, which is usually the visually top most / left most button.
 This can be set programmatically in an "appear" event handler via the `focusElement` action.
 
-##### (5) - `setAttribute`
+##### `setAttribute`
 
 Assigns a new value to given property for the script element, typically controlling a visual aspect of the underlying component.
 
@@ -790,11 +790,11 @@ value | New value for the underlying property.
 
 NOTE: On Roku, `setAttribute` manipulates the SceneGraph component underlying the BlueScript element. In effect, it allows access to underlying implementation for the element. This could have adverse effects.
 
-##### (6) - `flagActivityForAttention`
+##### `flagActivityForAttention`
 
 Flags the engagement as having been interacted with, fulfilling the interaction requirement of true[ATTENTION].
 
-##### (7) - `playSoundEffect`
+##### `playSoundEffect`
 
 Triggers a sound effect for playback.
 
@@ -806,7 +806,7 @@ NOTES: On Roku, `playSoundEffect` is a wrapper on top of the [`<SoundEffect/>`](
 
 On HTML5, the standard .mp3, .wav, etc. file types work.
 
-##### (8) - `debugLog`
+##### `debugLog`
 
 On Roku, prints a log message to BrightScript terminal. Attach ` | grep "debugLog: "` at the end of `telnet` comment to filter for `debugLog`.
 
@@ -825,7 +825,7 @@ value | The (string) value to print out. This can be a [Value or Expression](#va
 
 NOTES: We would always try to cast any types into string.
 
-##### (9) - `if/else`
+##### `if/else`
 
 The `if/else` Behavior Action is a conditional statement, which perform different actions depending on whether the `expression` boolean condition evaluates to true or false.
 
@@ -870,7 +870,7 @@ else | (optional) An array of Behavior Actions that should be executed if expres
 
 NOTE: There is no `else if` as of now.
 
-##### (10) - `for`
+##### `for`
 
 Behavior Action `for` is a control flow statement for specifying iteration, which allows Behavior Actions to be executed repeatedly. Requires a control variable with `from` and `to` values, and a `do` Behavior Actions Array. An optional `value` can be used to specified a "key" or "local" variable to assign the loop value to.
 
@@ -901,7 +901,7 @@ do | An array of Behavior Actions that should be executed
 
 NOTE: One can break out of the loop via a `break` action, or even a `return` action to exist the current event handler or function entirely.
 
-##### (11) - `assign`
+##### `assign`
 
 Behavior Action `assign` is an assignment statement that sets and/or re-sets the value stored in the storage denoted by a variable name (named by key); in other words, it copies a value into the variable.
 
@@ -930,7 +930,7 @@ value | Value of the variable (could be an expression).
 
 All globals values are maintained across step displays. Local variables are maintained during the current event handler or function invocation.
 
-##### (12) - `setTimeout`
+##### `setTimeout`
 
 Behavior Action `setTimeout` allows execution of a set of Behavior Actions at specified time intervals. (One time, or repeat)
 
@@ -952,11 +952,11 @@ do | An array of Behavior Actions to be executed.
 Creative is expected to stop their repeated timers.
 Currently there are no menthod to stop an individual timer.
 
-##### (13) - `stopAllTimers`
+##### `stopAllTimers`
 
 The `stopAllTimers` stops the execution of all the timers specified in setTimeout(), and clear all the saved timers.
 
-##### (14) - `makeWebRequest`
+##### `makeWebRequest`
 
 Enables Behavior Actions to read the HTTP values sent by a client during a Web request.
 
@@ -979,7 +979,7 @@ responseAsJson | (optional, default: false) will try to parse the return as JSON
 onload | An array of Behavior Actions to be executed on call successed.
 onerror | An array of Behavior Actions to be executed on call failed.
 
-##### (15) - `bringToFront`
+##### `bringToFront`
 
 Changes child order of a TXElement so that it draws on top of all other views.
 
@@ -987,7 +987,7 @@ Parameter | Description
 --- | ---
 name | Name of the node to bring to the front of the view
 
-##### (16) - `focusElement`
+##### `focusElement`
 
 Sets the focus to a specified button or video. onFocusGained and onFocusLost are triggered when switching focus.
 
@@ -995,29 +995,29 @@ Parameter | Description
 --- | ---
 name | Name of the node that will capture focus
 
-##### (17) - `disableUserInput`
+##### `disableUserInput`
 
 Prevent user input from being handled.
 
-##### (18) - `enableUserInput`
+##### `enableUserInput`
 
 Allow user input to be handled.
 
-##### (19) - `disableUserNavigation`
+##### `disableUserNavigation`
 
 Prevent user directional input from being handled.
 
-##### (20) - `enableUserNavigation`
+##### `enableUserNavigation`
 
 Allow user directional input to be handled
 
-##### (21) - `popStep`
+##### `popStep`
 
 [Deprecated: "step stacking" is no longer supported, not even available on HTML5. Use explicit `replaceStep` actions instead.]
 
 Removes the current BlueScript step from the stack, replacing it with the next step on the navigational stack.
 
-##### (22) - `animateElement`
+##### `animateElement`
 
 Animates Bluescript element attributes. This action is only supported on rendered elements (not Audio), and only with certain fields (see below).
 
@@ -1047,7 +1047,7 @@ More than one attribute can be animated with one call to `animateElement`.
  }
 ```
 
-##### (23) - `trackCustomEvent`
+##### `trackCustomEvent`
 
 Tracks an event back to the true[X] server. This can be used to report back custom events and activity done by a viewer in the unit, such that it can be used for client-facing reports later on.
 
@@ -1073,7 +1073,7 @@ category | `fep_roku_layout` | The tracking taxonomy category to use for the tra
 name | (required) | The name of the tracking event.
 value | | A value to use for the event, if appropriate.
 
-##### (24) - `setBounds`
+##### `setBounds`
 
 Instantly sets the bounds / position of an element.  An alternative to animateElement when duration = 0
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -271,7 +271,7 @@ There are also predefined keys that provide additional information dynamically
 
 Expressions are used to compare values, perform arithmetic operations, logical operations, and perform functions that return value (random, for example), given an array of `values` as input.
 
-*NOTE:* the older form of operation expressions was like:
+NOTE: the older form of operation expressions was like:
 ```json
 { "host" : "debugLog", "value" : {"operation": "+", "values": [123, 123] } }, 
 ```
@@ -419,8 +419,7 @@ Renders a single-colored rectangle at the specified screen coordinates.
 
 TXRectangle is a simple sub-class of Brightscript's [Rectangle](https://developer.roku.com/docs/references/scenegraph/renderable-nodes/rectangle.md) component that allows us to assign behaviors and play animations. All of the original Rectangle functionality is supported.
 
-#### Example
-
+For example:
 ```json
 {
    "type": "Rectangle",
@@ -447,8 +446,7 @@ blendingEnabled | true | Specifies if the rectangle should be alpha blended with
 Renders an image at the specified screen coordinates, such that the image is scaled to fit within the element's 
 specified size.
 
-#### Example
-
+For example:
 ```json
 {
    "type": "Image",
@@ -474,8 +472,7 @@ forceHighResolution | false | Use the image's native / high resolution on memory
 
 Renders a video at the specified screen coordinates.
 
-#### Example
-
+For example:
 ```json
 {
    "type"      : "Video",
@@ -524,8 +521,6 @@ On Roku, only a single Media node may be actively playing or buffering media at 
 
 Starts or resumes playback (for a paused video) for the target video.
 
-###### Parameters
-
 Parameter | Description
 --- | ---
 target | Name of the video to play.
@@ -533,8 +528,6 @@ target | Name of the video to play.
 ##### (2) - `pauseVideo`
 
 Pauses playback for the target video.
-
-###### Parameters
 
 Parameter | Description
 --- | ---
@@ -544,8 +537,6 @@ target | Name of the video to pause.
 
 Resets playback for the target video by setting the play head to the beginning.
 
-###### Parameters
-
 Parameter | Description
 --- | ---
 target | Name of the video to reset.
@@ -553,8 +544,6 @@ target | Name of the video to reset.
 ##### (4) - `stopVideo`
 
 Stops playback for the target video.
-
-###### Parameters
 
 Parameter | Description
 --- | ---
@@ -566,8 +555,7 @@ target | Name of the video to stop.
 
 Renders a text label at the specified screen coordinates.
 
-#### Example
-
+For example:
 ```json
 {
    "type"      : "Text",
@@ -650,8 +638,7 @@ Note: manipulating properties of the button such as `checked` can be achieved us
 
 Plays background audio.
 
-#### Example
-
+For example:
 ```json
 {
    "type"      : "Audio",
@@ -703,8 +690,7 @@ Stops playback for the active audio element.
 
 Renders a QR Code as image using the [qr-code-generator](https://github.com/socialvibe/ui_misc/tree/master/lambda_functions/qr-code-generator).
 
-#### Example
-
+For example:
 ```json
 {
    "type"     : "QRCode",
@@ -743,7 +729,7 @@ tagLabel | (empty) | Specifies if this QR Code should take its url from the tag 
 
 The following are the top-level events that behaviors can be triggered from:
 
-Behavior Event | Description
+Event | Description
 --- | ---
 appear | Triggered when the element's parent card is displayed. Note that appear does not tie to visibility.
 disappear | Triggered when the element's parent card is dismissed, such as on a card transition or when ending the ad flow.
@@ -775,16 +761,13 @@ Triggers the "Return to Content" button, exiting the ad flow for a completed ad.
 
 Navigates to a different BlueScript step, pushing the new step onto the navigational stack. A viewer is able to get back to the previous step using the BACK key or equivalent.
 
-Parameters:
-
-|   |   |
-| cardName | Name of the step to transition to, as defined in the top level list of BlueScript steps.
+Parameter | Description
+--- | ---
+cardName | Name of the step to transition to, as defined in the top level list of BlueScript steps.
 
 ##### (3) - `replaceStep`
 
 Navigates to a different BlueScript step, replacing the current step being displayed.
-
-###### Parameters
 
 Parameter | Description
 --- | ---
@@ -799,17 +782,13 @@ This can be set programmatically in an "appear" event handler via the `focusElem
 
 Assigns a new value to given property for the script element, typically controlling a visual aspect of the underlying component.
 
-###### Parameters
-
 Parameter | Description
 --- | ---
 name | Name of the BlueScript element that will have one of its underlying properties changed.
 key | Name of the underlying property to update.
 value | New value for the underlying property.
 
-###### Notes
-
-On Roku, `setAttribute` manipulates the SceneGraph component underlying the BlueScript element. In effect, it allows access to underlying implementation for the element. This could have adverse effects.
+NOTE: On Roku, `setAttribute` manipulates the SceneGraph component underlying the BlueScript element. In effect, it allows access to underlying implementation for the element. This could have adverse effects.
 
 ##### (6) - `flagActivityForAttention`
 
@@ -819,15 +798,11 @@ Flags the engagement as having been interacted with, fulfilling the interaction 
 
 Triggers a sound effect for playback.
 
-###### Parameters
-
 Parameter | Description
 --- | ---
 uri | Uri of the sound file to trigger playback for.
 
-###### Notes
-
-On Roku, `playSoundEffect` is a wrapper on top of the [`<SoundEffect/>`](https://sdkdocs.roku.com/display/sdkdoc/SoundEffect) SceneGraph component. It is notably limited to WAV files as a format for the sound effects.
+NOTES: On Roku, `playSoundEffect` is a wrapper on top of the [`<SoundEffect/>`](https://sdkdocs.roku.com/display/sdkdoc/SoundEffect) SceneGraph component. It is notably limited to WAV files as a format for the sound effects.
 
 On HTML5, the standard .mp3, .wav, etc. file types work.
 
@@ -837,28 +812,24 @@ On Roku, prints a log message to BrightScript terminal. Attach ` | grep "debugLo
 
 On HTML5, prints a log message to the browser's console log. Examine the console log of the browser the ad is running in.
 
-###### Example
+For example:
 ```json
 { "host" : "debugLog", "value" : "This is a String." }, // Prints: This is a String.
 { "host" : "debugLog", "value" : {"key": "keyOfValue"}  }, // Prints: what ever is in keyOfValue.
 { "host" : "debugLog", "value" : {"+": ["Plus ", "operation."]}  }, // Prints: Plus operation.
 ```
 
-###### Parameters
-
 Parameter | Description
 --- | ---
 value | The (string) value to print out. This can be a [Value or Expression](#values-and-expressions).
 
-###### Notes
-
-We would always try to cast any types into string.
+NOTES: We would always try to cast any types into string.
 
 ##### (9) - `if/else`
 
 The `if/else` Behavior Action is a conditional statement, which perform different actions depending on whether the `expression` boolean condition evaluates to true or false.
 
-###### Example
+For example:
 ```json
  { "host" : "if",
    "expression" : true,
@@ -891,23 +862,19 @@ The `if/else` Behavior Action is a conditional statement, which perform differen
                 "value" : "4) txLogLevel is not 3" }] }
 ```
 
-###### Parameters
-
 Parameter | Description
 --- | ---
 expression | Expression is a [Value or Expression](#values-and-expressions), which determines the flow of the Behavior Actions
 then | An array of Behavior Actions that should be executed if expression is true
 else | (optional) An array of Behavior Actions that should be executed if expression is NOT true
 
-###### Notes
-
-There is no `else if` as of now.
+NOTE: There is no `else if` as of now.
 
 ##### (10) - `for`
 
 Behavior Action `for` is a control flow statement for specifying iteration, which allows Behavior Actions to be executed repeatedly. Requires a control variable with `from` and `to` values, and a `do` Behavior Actions Array. An optional `value` can be used to specified a "key" or "local" variable to assign the loop value to.
 
-###### Example
+For example:
 ```json
  { "host" : "for",
    "from": 0,
@@ -925,8 +892,6 @@ Behavior Action `for` is a control flow statement for specifying iteration, whic
    ] },
 ```
 
-###### Parameters
-
 Parameter | DescriptionG
 --- | ---
 value | (optional) Local or key variable that the counter should save to. Default `{ "key": "forI" }`
@@ -934,15 +899,13 @@ from | An integer value that the loop counter would start from (could be [Value 
 to | An integer value that the loop counter would count to (inclusive) (could be [Value or Expression](#values-and-expressions))
 do | An array of Behavior Actions that should be executed
 
-###### Notes
-
-One can break out of the loop via a `break` action, or even a `return` action to exist the current event handler or function entirely.
+NOTE: One can break out of the loop via a `break` action, or even a `return` action to exist the current event handler or function entirely.
 
 ##### (11) - `assign`
 
 Behavior Action `assign` is an assignment statement that sets and/or re-sets the value stored in the storage denoted by a variable name (named by key); in other words, it copies a value into the variable.
 
-###### Example
+For example:
 ```json
  { "host" : "assign",
    "key" : "i",
@@ -959,8 +922,6 @@ Behavior Action `assign` is an assignment statement that sets and/or re-sets the
  }
 ```
 
-###### Parameters
-
 Parameter | Description
 --- | ---
 key | Name of global variable. It can be a dot seperated list to indicate variable inside objects, or array. (could be [value or expression](#values-and-expressions))
@@ -973,14 +934,12 @@ All globals values are maintained across step displays. Local variables are main
 
 Behavior Action `setTimeout` allows execution of a set of Behavior Actions at specified time intervals. (One time, or repeat)
 
-###### Example
+For example:
 ```json
  { "host" : "setTimeout",
    "duration" : 3,
    "do": [ { "host" : "debugLog", "value" : "timeout fired after 3 seconds" } ] }
 ```
-
-###### Parameters
 
 Parameter | Description
 --- | ---
@@ -1001,7 +960,7 @@ The `stopAllTimers` stops the execution of all the timers specified in setTimeou
 
 Enables Behavior Actions to read the HTTP values sent by a client during a Web request.
 
-###### Example
+For example:
 ```json
  { "host" : "makeWebRequest",
    "url" : "https://api.weather.gov/gridpoints/SEW/124,67/forecast/hourly",
@@ -1011,8 +970,6 @@ Enables Behavior Actions to read the HTTP values sent by a client during a Web r
              { "host" : "debugLog",
                "value" : { "key": "weatherJson.properties.periods.0" } } ] }
 ```
-
-###### Parameters
 
 Parameter | Description
 --- | ---
@@ -1026,8 +983,6 @@ onerror | An array of Behavior Actions to be executed on call failed.
 
 Changes child order of a TXElement so that it draws on top of all other views.
 
-###### Parameters
-
 Parameter | Description
 --- | ---
 name | Name of the node to bring to the front of the view
@@ -1035,8 +990,6 @@ name | Name of the node to bring to the front of the view
 ##### (16) - `focusElement`
 
 Sets the focus to a specified button or video. onFocusGained and onFocusLost are triggered when switching focus.
-
-###### Parameters
 
 Parameter | Description
 --- | ---
@@ -1068,8 +1021,6 @@ Removes the current BlueScript step from the stack, replacing it with the next s
 
 Animates Bluescript element attributes. This action is only supported on rendered elements (not Audio), and only with certain fields (see below).
 
-###### Parameters
-
 Parameter | Default | Description
 --- | --- | ---
 attributes | (required) | and object defining which attributes are to be animated; (x, y, width, height and opacity. position and size are supported legacy attributes)
@@ -1100,8 +1051,7 @@ More than one attribute can be animated with one call to `animateElement`.
 
 Tracks an event back to the true[X] server. This can be used to report back custom events and activity done by a viewer in the unit, such that it can be used for client-facing reports later on.
 
-###### Example
-
+For example:
 ```json
  { "host" : "trackCustomEvent",
    "name" : "button_clicked",
@@ -1117,8 +1067,6 @@ Tracks an event back to the true[X] server. This can be used to report back cust
  }
 ```
 
-###### Parameters
-
 Parameter | Default | Description
 --- | --- | ---
 category | `fep_roku_layout` | The tracking taxonomy category to use for the tracking call. Typically omitted so default value is used.
@@ -1128,8 +1076,6 @@ value | | A value to use for the event, if appropriate.
 ##### (24) - `setBounds`
 
 Instantly sets the bounds / position of an element.  An alternative to animateElement when duration = 0
-
-###### Parameters
 
 Parameter | Default | Description
 --- | --- | ---

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -9,7 +9,7 @@ _rev. 2020-06-08_
    1. [Examples](#examples)
 1. [Element Reference](#bluescript-element-reference)
    1. [Step](#step)
-   1. [Value Object](#value-object)
+   1. [Values and Expressions](#values-and-expressions)
    1. [Rectangle](#rectangle)
    1. [Image](#image)
    1. [Video](#video)
@@ -284,7 +284,7 @@ On HTML5, prints a log message to the browser's console log. Examine the console
 
 Parameter | Description
 --- | ---
-value | The (string) value to print out. This can be a Value Object, see Value Object session for useage.
+value | The (string) value to print out. This can be a [Value or Expression](#values-and-expressions).
 
 ###### Notes
 
@@ -331,7 +331,7 @@ The `if/else` Behavior Action is a conditional statement, which perform differen
 
 Parameter | Description
 --- | ---
-expression | Expression is a Value Object, which determines the flow of the Behavior Actions
+expression | Expression is a [Value or Expression](#values-and-expressions), which determines the flow of the Behavior Actions
 then | An array of Behavior Actions that should be executed if expression is true
 else | (optional) An array of Behavior Actions that should be executed if expression is NOT true
 
@@ -363,11 +363,11 @@ Behavior Action `for` is a control flow statement for specifying iteration, whic
 
 ###### Parameters
 
-Parameter | Description
+Parameter | DescriptionG
 --- | ---
-value | (optional) Value Object variable that the counter should save to. Default `{ "key": "forI" }`
-from | An integer value that the loop counter would start from (could be Value Object)
-to | An integer value that the loop counter would count to (inclusive) (could be Value Object)
+value | (optional) Local or key variable that the counter should save to. Default `{ "key": "forI" }`
+from | An integer value that the loop counter would start from (could be [Value or Expression](#values-and-expressions))
+to | An integer value that the loop counter would count to (inclusive) (could be [Value or Expression](#values-and-expressions))
 do | An array of Behavior Actions that should be executed
 
 ###### Notes
@@ -399,8 +399,8 @@ Behavior Action `assign` is an assignment statement that sets and/or re-sets the
 
 Parameter | Description
 --- | ---
-key | Name of variable. It can be a dot seperated list to indicate variable inside objects, or array. (could be Value Object)
-value | Value of the variable. (could be Value Object)
+key | Name of variable. It can be a dot seperated list to indicate variable inside objects, or array. (could be [Value or Expression](#values-and-expressions))
+value | Value of the variable. (could be [Value or Expression](#values-and-expressions))
 
 ###### Notes
 
@@ -600,9 +600,9 @@ category | `fep_roku_layout` | The tracking taxonomy category to use for the tra
 name | N/A (required) | The name of the tracking event.
 value | | A value to use for the event, if appropriate.
 
-### Value Object
+### Values and Expressions
 
-The variable Behavior Actions take as input. There are 3 types:
+The values behavior actions take as input. There are 3 types:
 1 - Literal Values
 2 - Stored Values
 3 - Expressions
@@ -663,7 +663,7 @@ The global key variables stored in the Behavior Action sandbox.
 
 Parameter | Description
 --- | ---
-key | Name of variable. It can be a dot seperated list to indicate variable inside objects, or array. (could be another Value Object)
+key | Name of variable. It can be a dot seperated list to indicate variable inside objects, or array. (could be another [Value or Expression](#values-and-expressions))
 
 ##### (2) - Local Values
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -51,12 +51,12 @@ Each step card contains a flat list of BlueScript elements. There is implied hie
 
 BlueScript elements support event handlers, enabling dynamic behavior. These can be used to trigger a variety of supported actions, such as controlling a video or playing sound effects. This is expressed as lists of behavior actions keyed on events. See below and `southback` repo (for Roku) and `Skyline` repo (for HTML5) for examples of this.
 
-## (1) Overall Structure 1
+## Overall Structure
 
-### (1) Top Level Syntax 1.1
+### Top Level Syntax
 > _**Formatting note**: strings inside of carets (`"< ... >"`) are meta-descriptions, not absolute values_
 
-**Schema:**
+Schema:
 ```json
 {
   "steps": [
@@ -121,28 +121,16 @@ the [element reference section](#bluescript-element-reference) below.
 
 #### Behaviors
 
-A step's "behaviors" property contains all behaviors for each element of the step - is an object with keys that match element names:
-* **\<NAME\>** - Name of the BlueScript element that the child behaviors are associated with
-  and has an array value that defines the behavior "host" action of the object for each event (see below).
+A step's "behaviors" property contains all behaviors for each element of the step - is an object with keys that match element names to a map of event handlers, where each event handler maps to an array of [behavior actions](#behavior-actions) to execute when the event occurs. BlueScript elements can define any number of behavior actions for any number of events.
 
-Property | Default | Description
---- | --- | ---
-Element Name | {} | An object that defines the behavior on events. Each base behavior contains an array of actions.
-
-For each event, an array of [behavior actions](#behavior-actions) can be defined. BlueScript elements can define any number of behavior actions for any number of events.
-
-Property | Default | Description
---- | --- | ---
-behavior | {} | Defines the list of [behavior actions](#behavior-actions) to be triggered on specific [named events](#behavior-events).
-
-<summary>For example:</summary>
-
+For example:
 ```json
 {
   "behaviors": {
-    "fooLabel": {
+    "button1": {
       "appear": [ <ACTIONS> ],
-      "disappear": [ <ACTIONS> ]
+      "disappear": [ <ACTIONS> ],
+      "onSelect": [ <ACTIONS> ]
     }
   }
 }

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -15,8 +15,6 @@ _rev. 2020-06-08_
          1. [Behavior Events](#behavior-events)
          1. [Behavior Actions](#behavior-actions)
       1. [Functions](#functions)
-   1. [Step](#step)
-   1. [Step](#step)
    1. [Rectangle](#rectangle)
    1. [Image](#image)
    1. [Video](#video)
@@ -172,12 +170,12 @@ now recommended, as shown below.
  { "host" : "debugLog", "value" : {"!": true } },
 ```
 
-###### Functions Operations Example
+###### Misc Operations Example
 ```json
  { "host" : "debugLog", "value" : {"random": 10 } },
 ```
 
-###### Expression format:
+###### Operation Expression format:
 
 {"<operation>": <values>}
 
@@ -218,10 +216,6 @@ zeroFill | Fill number with leading 0s | 2 | Number | `{"zeroFill": [123, 5]}`  
 formatMinutesSeconds | Format seconds as `MM:SS`, or `H:MM:SS` if over an hour | 1 | Number | `{"formatMinutesSeconds": 3599}` returns `"59:59"` | -
 formatHoursMinutesSeconds | Format seconds as `H:MM:SS` | 1 | Number | `{"formatMinutesSeconds": 3599}` returns `"0:59:59"` | -
 ---
-
-### Functions
-
-TBD
 
 ### BlueScript Element Syntax
 
@@ -764,6 +758,14 @@ height |  | new height of element
 ###### Notes
 
 All new values are optional by excluding them in the action.  For example, if you only want to change x,y and leave width,height alone.
+
+---
+
+#### Functions
+
+TBD
+
+---
 
 ### Rectangle
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -600,13 +600,6 @@ category | `fep_roku_layout` | The tracking taxonomy category to use for the tra
 name | N/A (required) | The name of the tracking event.
 value | | A value to use for the event, if appropriate.
 
-### Values and Expressions
-
-The values behavior actions take as input. There are 3 types:
-1 - Literal Values
-2 - Stored Values
-3 - Expressions
-
 ##### (24) - `setBounds`
 
 Instantly sets the bounds / position of an element.  An alternative to animateElement when duration = 0
@@ -624,6 +617,13 @@ height |  | new height of element
 ###### Notes
 
 All new values are optional by excluding them in the action.  For example, if you only want to change x,y and leave width,height alone.
+
+### Values and Expressions
+
+The values behavior actions take as input. There are 3 types:
+1 - Literal Values
+2 - Stored Values
+3 - Expressions
 
 ##### (1) - Literal Values
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -916,6 +916,23 @@ NOTE: There is no `else if` as of now.
 
 ---
 
+##### `invoke`
+
+Invokes the specified function, allowing for the reuse of common behavior actions. 
+See the [Functions section](#functions) for more details.
+
+For example:
+```json
+{"host": "invoke", "function": "testFunction", "args": {"x": 123}}
+```
+
+Parameter | Description
+--- | ---
+function | The name of the function to invoke. It will be defined in the "functions" object of the current step.
+args | The optional map of named arguments to pass to the function.
+
+---
+
 ##### `makeWebRequest`
 
 Enables Behavior Actions to read the HTTP values sent by a client during a Web request.

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -511,43 +511,9 @@ downFocus | invalid | ID of element to focus when down directional button is pre
 autoFocus | false | If set to true, the video (if focusable) will be focused by default.
 useRotation | false | If set to true, will ignore the video url and try to apply the value of `video_n` from the ad parameters.
 
-#### Notes
+NOTE: On Roku, only a single Media node may be actively playing or buffering media at a given time. This means that it is not possible to have multiple inline videos playing concurrently or a background / ambient video with inline window windows on top. This also precludes the use of background audio playing together with a video.
 
-On Roku, only a single Media node may be actively playing or buffering media at a given time. This means that it is not possible to have multiple inline videos playing concurrently or a background / ambient video with inline window windows on top. This also precludes the use of background audio playing together with a video.
-
-#### Video Behavior Actions
-
-##### `playVideo`
-
-Starts or resumes playback (for a paused video) for the target video.
-
-Parameter | Description
---- | ---
-target | Name of the video to play.
-
-##### `pauseVideo`
-
-Pauses playback for the target video.
-
-Parameter | Description
---- | ---
-target | Name of the video to pause.
-
-##### `resetVideo`
-
-Resets playback for the target video by setting the play head to the beginning.
-
-Parameter | Description
---- | ---
-target | Name of the video to reset.
-
-##### `stopVideo`
-
-Stops playback for the target video.
-
-Parameter | Description
---- | ---
-target | Name of the video to stop.
+Related video actions: [playVideo](#playVideo), [pauseVideo](#pauseVideo), [resetVideo](#resetVideo), [stopVideo](#stopVideo)
 
 ---
 
@@ -660,29 +626,12 @@ loop | true | If set to true, the audio will restart from the beginning after th
 autoplay | true | If set to true, the audio will be automatically started on card display.
 global | false | If true, audio sticks/continues playing across step card transitions.
 
-#### Notes
+NOTES:
+* On Roku, only a single Media node may be actively playing or buffering media at a given time. This means that it is not possible to have multiple inline videos playing concurrently or a background / ambient video with inline window windows on top. This also precludes the use of background audio playing together with a video. Any additional stream started after the first one will fail silently.
+* For the MP3 format. On the PlayStation 5 and some other platforms, MP3 is not supported. BlueScript engine will try to get the MP4 version (same location, same name) of the given audio instead. Asset Uploader in True Exchange is encoding that MP4 file automatically. Be sure to include a MP4 version of your audio file if you cannot use the Asset Uploader.
 
-On Roku, only a single Media node may be actively playing or buffering media at a given time. This means that it is not possible to have multiple inline videos playing concurrently or a background / ambient video with inline window windows on top. This also precludes the use of background audio playing together with a video. Any additional stream started after the first one will fail silently.
-
-Note on MP3 format. On PlayStation, and some other platforms, MP3 is not supported. BlueScript engine will try to get the MP4 version (same location, same name) of the given audio instead. Asset Uploader in True Exchange is encoding that MP4 file automatically. Be sure to include a MP4 version of your audio file if you cannot use the Asset Uploader.
-
-#### Audio Behavior Actions
-
-##### `playActiveAudio`
-
-Starts or resumes playback (if currently paused) for the active audio element.
-
-##### `pauseActiveAudio`
-
-Pauses playback for the active audio element.
-
-##### `resetActiveAudio`
-
-Resets playback for the active audio element by setting the play head to the beginning.
-
-##### `stopActiveAudio`
-
-Stops playback for the active audio element.
+Related audio actions: [playActiveAudio](#playActiveAudio), [pauseActiveAudio](#pauseActiveAudio), 
+[resetActiveAudio](#resetActiveAudio), [stopActiveAudio](#stopActiveAudio)
 
 ---
 
@@ -750,6 +699,54 @@ videoDidExitFullscreen | Triggered when video is set back to its original size.
 
 This section details the behavior actions that can be scripted. Actions are invoked when Events occur, 
 or when a BlueScript function is invoked.
+
+##### `playActiveAudio`
+
+Starts or resumes playback (if currently paused) for the active audio element.
+
+##### `pauseActiveAudio`
+
+Pauses playback for the active audio element.
+
+##### `resetActiveAudio`
+
+Resets playback for the active audio element by setting the play head to the beginning.
+
+##### `stopActiveAudio`
+
+Stops playback for the active audio element.
+
+##### `playVideo`
+
+Starts or resumes playback (for a paused video) for the target video.
+
+Parameter | Description
+--- | ---
+target | Name of the video to play.
+
+##### `pauseVideo`
+
+Pauses playback for the target video.
+
+Parameter | Description
+--- | ---
+target | Name of the video to pause.
+
+##### `resetVideo`
+
+Resets playback for the target video by setting the play head to the beginning.
+
+Parameter | Description
+--- | ---
+target | Name of the video to reset.
+
+##### `stopVideo`
+
+Stops playback for the target video.
+
+Parameter | Description
+--- | ---
+target | Name of the video to stop.
 
 ##### `allDoneButtonPushed`
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -964,7 +964,7 @@ Parameter | Default | Description
 url | (required) | The server/file location.
 method | "GET" | one of "GET", "PUT", "POST", "DELETE", "HEAD"
 headers | { "Accept": "application/json",<br/> "Content-Type": "application/json" } | object map of header names to values.
-body | null | if present, sent as the body of the request for PUT and POST requests.<br/>Strings are sent as is, objects converted to form encoding for "application/x-www-form-urlencoded" content type requests, JSON otherwise.
+body | null | if present, sent as the body of the request for PUT and POST requests.<br/>Strings are sent as is, objects are converted to form encoding for "application/x-www-form-urlencoded" content type requests, JSON otherwise.
 assignResponseTo | optional | takes a `key` or `local` variable reference, to be assigned the returned string/json response.
 responseAsJson | false | will try to parse the return as JSON before applying the response
 onload | optional | An array of Behavior Actions to be executed on call successed.

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -956,10 +956,8 @@ Parameter | Default | Description
 --- | ---
 url | (required) | The server/file location.
 method | "GET" | one of "GET", "PUT", "POST", "DELETE", "HEAD"
-headers | { "Accept": "application/json",
- "Content-Type": "application/json" } | object map of header names to values, defaults
-body | null | if present, sent as the body of the request for PUT and POST requests. Strings are sent as is, objects
- converted to form encoding for "application/x-www-form-urlencoded" content type requests, JSON otherwise.
+headers | { "Accept": "application/json", "Content-Type": "application/json" } | object map of header names to values, defaults
+body | null | if present, sent as the body of the request for PUT and POST requests. Strings are sent as is, objects converted to form encoding for "application/x-www-form-urlencoded" content type requests, JSON otherwise.
 assignResponseTo | optional | takes a `key` or `local` variable reference, to be assigned the returned string/json response.
 responseAsJson | false | will try to parse the return as JSON before applying the response
 onload | optional | An array of Behavior Actions to be executed on call successed.

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -238,7 +238,7 @@ For HTML5: See the [sample-bluescript.json](https://github.com/socialvibe/truex-
 
 ## BlueScript Element Reference
 
-This section documents the base properties and behaviors inherited by all other BlueScript elements.
+This section documents the available elements available for creating the diplayed UX of a step.
 
 ### Step
 
@@ -313,7 +313,41 @@ behavior | {} | Defines the list of [behavior actions](#behavior-actions) to be 
 
 #### Functions
 
-TBD
+A step's "functions" property contains all reusable functions, keyed by function name, that can be called from other event action execution, expressions, and even other functions.
+
+One uses the `invoke` behavior action or expression to execute functions. Arguments are passed by name, and are referred to with the function via the `arg` expression.
+
+The `return` host action can be used to return from the function immediately.
+
+Local variable values can be assigned via the `local` assign action. Such variables exist only during the current invocation's execution.
+
+<summary>For example:</summary>
+```json
+{
+  "elements": [...],
+  "functions": {
+    "testFunction": [
+      {"host": "assign", "local": "v", "value": {"arg": "x"}}
+      {"host": "return", "value": {"+": [{"local": "v"}, {"local": "v"}]}}
+    ]
+  },
+  "behaviors": {
+    "testButton": {
+      "appear": [
+        {
+	  "host": "invoke",
+	  "function": "testFunction",
+	  "args": {"x": 123}
+	},
+        {
+	  "host": "debugLog",
+	  "value": {"invoke": "testFunction", "args": {"x": 123}}
+	}
+      ]
+    }
+  }
+}
+```
 
 ---
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -339,7 +339,7 @@ now recommended, as shown with the examples below:
 { "host" : "debugLog", "value" : {"local":  "now.time"} },           // 1631316792480, e.g. millis since Jan 1, 1970
 
 {"host": "assign", "local": "now", "value":  {"date":  1631316792480}}, // from timestamp
-{"host": "assign", "local": "nextWeek", "value": {"+": [{"local": "now.time"}, {"*": [7, 24, 60, 60, 1000]}}, // next week
+{"host": "assign", "local": "nextWeek", "value": {"+": [{"local": "now.time"}, {"*": [7, 24, 60, 60, 1000]}]}}, // next week
 
 { "host": "assign", "local": "yearStart", "value":  {"date": {"year": 2021}} },
 { "host" : "debugLog", "value" : {"local": "yearStart.month"} },   // 1

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -97,8 +97,8 @@ the use of global "key variables" if they need to programmatically restore a pre
 
 Step Property | Default | Description
 --- | --- | ---
-name | N/A (Required) | Name (String) of the step and used to identify it for behaviors.
-elements | N/A (Required) | An array that contains [elements](#bluescript-element-reference) of this step. Z-indexed by the order, the first element is on the top, the last element is at the bottom.
+name | (required) | Name (String) of the step and used to identify it for behaviors.
+elements | (required) | An array that contains [elements](#bluescript-element-reference) of this step. Z-indexed by the order, the first element is on the top, the last element is at the bottom.
 behaviors | {} (Optional)| An object containing [named event handlers](#behavior-events), which define the behavior of elements, by their element names.
 functions | {} (Optional) | An object containing named functions, which can be invoked from behavior events and other functions.
 
@@ -108,8 +108,8 @@ A step's "elements" defines the array of BlueScript visual elements that are to 
 
 Element Property | Default | Description
 --- | --- | ---
-type | N/A (Required) | Type for the BlueScript element. See [possible element types below](#bluescript-element-reference) for what is supported.
-name | N/A (Required) | Name of the element and used to identify it for behaviors.
+type | (required) | Type for the BlueScript element. See [possible element types below](#bluescript-element-reference) for what is supported.
+name | (required) | Name of the element and used to identify it for behaviors.
 x | 0 | Screen-space X position, where x=0 is the left side of the (assumed 1080p) screen
 y | 0 | Screen-space Y position, where y=0 is the top of the (assumed 1080p) screen
 width | 0 | Specifies the width of the element on the screen. If 0 the width is computed dynamically from the element's visual content.
@@ -465,7 +465,7 @@ specified size.
 
 Property | Default | Description
 --- | --- | ---
-image_url | N/A (Required) | Specifies the URI to the image file.
+image_url | (required) | Specifies the URI to the image file.
 forceHighResolution | false | Use the image's native / high resolution on memory constrained low end Roku devices. See below [Memory Management](#memory-management) note.
 
 ---
@@ -495,7 +495,7 @@ Renders a video at the specified screen coordinates.
 
 Property | Default | Description
 --- | --- | ---
-video_url | N/A (Required) | Specifies the URI to the video file. MP4 format is expected.
+video_url | (required) | Specifies the URI to the video file. MP4 format is expected.
 loop | true | If set to true, the video will be restarted from the beginning after the end is reached.
 autoplay | true | If set to true, the video will be automatically started on card display.
 replayable | false | If set to true, makes the video player focusable on playback completion, enabling replay of the video.
@@ -503,7 +503,7 @@ mute | false | Set to true to mute the audio of the video currently playing. Set
 fullscreen | false | When toggled, the video will be animated to fullscreen, or back to window
 zoomAnimationDuration | 0.35 | The time it takes to animated between window and fullscreen. The 0.35 is copie from tvOS TAR. (Note: must be > 0)
 easeFunction | "inOutCubic" | This string defines the animation curve. For full list of easeFunction, see: https://sdkdocs.roku.com/display/sdkdoc/Animation#Animation-Fields
-currentTime | N/A | This value is the floating point time of the current stream.  This has a margin of error of 500ms due to how position is handled.
+currentTime | 0 | This value is the floating point time of the current stream.  This has a margin of error of 500ms due to how position is handled.
 trackingName | | When set, tracking calls utilize this name instead of the uri to identify videos. Greatly facilitates analysis. Note that when `useRotation` set to true, a `_n` suffix will be added to the trackingName, where `n` is the index of the video with "1 indexing".
 preview_image_url | | When set, implements a static image to overlay on top of the video player on video playback completion.
 focusable | false | Set to true in order to make the video focusable.
@@ -627,7 +627,7 @@ For example:
 
 Property | Default | Description
 --- | --- | ---
-image_url | N/A (Required) | Specifies the URI to the image file used for the button.
+image_url | (required) | Specifies the URI to the image file used for the button.
 hover_image_url |  | Specifies the URI to the image file used for the button's focused state.
 checked_image_url |  | Specifies the URI to the image file used for the button's enabled or checked state.
 hover_checked_image_url |  | Specifies the URI to the image file used for the button's focused state when it is used as a toggle style button.
@@ -642,17 +642,7 @@ upFocus | invalid | ID of element to focus when up directional button is pressed
 downFocus | invalid | ID of element to focus when down directional button is pressed.
 autoFocus | false | If set to true, the button will be focused by default.
 
-#### Button Behavior Events
-
-Behavior Event | Description
---- | ---
-onFocusGained | Triggered when the button receives focus.
-onFocusLost | Triggered when the button loses focus.
-onSelect | Triggered when the button is selected.
-
-#### Button Behavior Actions
-
-N/A. Note: manipulating properties of the button such as `checked` can be achieved using the `setAttribute` behavior action.
+Note: manipulating properties of the button such as `checked` can be achieved using the `setAttribute` behavior action.
 
 ---
 
@@ -678,7 +668,7 @@ Note: visual properties are not relevant for the Audio element, e.g. x, y, width
 
 Property | Default | Description
 --- | --- | ---
-audio_url | N/A (Required) | Specifies the URI to the audio file. MP3 format* is expected. Always use the Asset Uploader.
+audio_url | (required) | Specifies the URI to the audio file. MP3 format* is expected. Always use the Asset Uploader.
 loop | true | If set to true, the audio will restart from the beginning after the end is reached.
 autoplay | true | If set to true, the audio will be automatically started on card display.
 global | false | If true, audio sticks/continues playing across step card transitions.
@@ -695,33 +685,17 @@ Note on MP3 format. On PlayStation, and some other platforms, MP3 is not support
 
 Starts or resumes playback (if currently paused) for the active audio element.
 
-###### Parameters
-
-N/A
-
 ##### (2) - `pauseActiveAudio`
 
 Pauses playback for the active audio element.
-
-###### Parameters
-
-N/A
 
 ##### (3) - `resetActiveAudio`
 
 Resets playback for the active audio element by setting the play head to the beginning.
 
-###### Parameters
-
-N/A
-
 ##### (4) - `stopActiveAudio`
 
 Stops playback for the active audio element.
-
-###### Parameters
-
-N/A
 
 ---
 
@@ -795,10 +769,6 @@ or when a BlueScript function is invoked.
 
 Triggers the "Return to Content" button, exiting the ad flow for a completed ad.
 
-###### Parameters
-
-N/A
-
 ##### (2) - `showStep`
 
 [Deprecated: "step stacking" is no longer upported, not even available on HTML5. Use explicit `replaceStep` actions instead.]
@@ -826,10 +796,6 @@ cardName | Name of the step to transition to, as defined in the top level list o
 Re-initializes the focus handler and ensures a default control is focused, which is usually the visually top most / left most button.
 This can be set programmatically in an "appear" event handler via the `focusElement` action.
 
-###### Parameters
-
-N/A
-
 ##### (5) - `setAttribute`
 
 Assigns a new value to given property for the script element, typically controlling a visual aspect of the underlying component.
@@ -849,10 +815,6 @@ On Roku, `setAttribute` manipulates the SceneGraph component underlying the Blue
 ##### (6) - `flagActivityForAttention`
 
 Flags the engagement as having been interacted with, fulfilling the interaction requirement of true[ATTENTION].
-
-###### Parameters
-
-N/A
 
 ##### (7) - `playSoundEffect`
 
@@ -1085,43 +1047,23 @@ name | Name of the node that will capture focus
 
 Prevent user input from being handled.
 
-###### Parameters
-
-N/A
-
 ##### (18) - `enableUserInput`
 
 Allow user input to be handled.
-
-###### Parameters
-
-N/A
 
 ##### (19) - `disableUserNavigation`
 
 Prevent user directional input from being handled.
 
-###### Parameters
-
-N/A
-
 ##### (20) - `enableUserNavigation`
 
 Allow user directional input to be handled
-
-###### Parameters
-
-N/A
 
 ##### (21) - `popStep`
 
 [Deprecated: "step stacking" is no longer supported, not even available on HTML5. Use explicit `replaceStep` actions instead.]
 
 Removes the current BlueScript step from the stack, replacing it with the next step on the navigational stack.
-
-##### Parameters
-
-N/A
 
 ##### (22) - `animateElement`
 
@@ -1131,7 +1073,7 @@ Animates Bluescript element attributes. This action is only supported on rendere
 
 Parameter | Default | Description
 --- | --- | ---
-attributes | N/A (required) | and object defining which attributes are to be animated; (x, y, width, height and opacity. position and size are supported legacy attributes)
+attributes | (required) | and object defining which attributes are to be animated; (x, y, width, height and opacity. position and size are supported legacy attributes)
 duration | 0.35 | the length of time (in seconds) it will take to play the animation
 easeFunction | `outCubic` | how the values will evolve throughout the animation duration
 optional | false | (Roku only) whether or not the animation can be ignored for low-end devices under stress
@@ -1181,7 +1123,7 @@ Tracks an event back to the true[X] server. This can be used to report back cust
 Parameter | Default | Description
 --- | --- | ---
 category | `fep_roku_layout` | The tracking taxonomy category to use for the tracking call. Typically omitted so default value is used.
-name | N/A (required) | The name of the tracking event.
+name | (required) | The name of the tracking event.
 value | | A value to use for the event, if appropriate.
 
 ##### (24) - `setBounds`

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -963,7 +963,7 @@ Parameter | Default | Description
 --- | --- | ---
 url | (required) | The server/file location.
 method | "GET" | one of "GET", "PUT", "POST", "DELETE", "HEAD"
-headers | { "Accept": "application/json",<br/> "Content-Type": "application/json" } | object map of header names to values, defaults
+headers | { "Accept": "application/json",<br/> "Content-Type": "application/json" } | object map of header names to values.
 body | null | if present, sent as the body of the request for PUT and POST requests.<br/>Strings are sent as is, objects converted to form encoding for "application/x-www-form-urlencoded" content type requests, JSON otherwise.
 assignResponseTo | optional | takes a `key` or `local` variable reference, to be assigned the returned string/json response.
 responseAsJson | false | will try to parse the return as JSON before applying the response

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -939,22 +939,31 @@ Enables Behavior Actions to read the HTTP values sent by a client during a Web r
 
 For example:
 ```json
- { "host" : "makeWebRequest",
+{
+   "host" : "makeWebRequest",
    "url" : "https://api.weather.gov/gridpoints/SEW/124,67/forecast/hourly",
+   "method": "GET",
+   "headers": {"Accept": "application/json"},
    "responseAsJson": true,
    "assignResponseTo": { "key": "weatherJson" },
    "onload": [
-             { "host" : "debugLog",
-               "value" : { "key": "weatherJson.properties.periods.0" } } ] }
+      { "host" : "debugLog", "value" : { "key": "weatherJson.properties.periods.0" } } 
+   ]
+}
 ```
 
-Parameter | Description
+Parameter | Default | Description
 --- | ---
-url | The server/file location.
-assignResponseTo | takes a variable reference with a `key` or `local` entry, which points to variable that the returned string/json will be assigned to.
-responseAsJson | (optional, default: false) will try to parse the return as JSON before save.
-onload | An array of Behavior Actions to be executed on call successed.
-onerror | An array of Behavior Actions to be executed on call failed.
+url | (required) | The server/file location.
+method | "GET" | one of "GET", "PUT", "POST", "DELETE", "HEAD"
+headers | { "Accept": "application/json",
+ "Content-Type": "application/json" } | object map of header names to values, defaults
+body | null | if present, sent as the body of the request for PUT and POST requests. Strings are sent as is, objects
+ converted to form encoding for "application/x-www-form-urlencoded" content type requests, JSON otherwise.
+assignResponseTo | optional | takes a `key` or `local` variable reference, to be assigned the returned string/json response.
+responseAsJson | false | will try to parse the return as JSON before applying the response
+onload | optional | An array of Behavior Actions to be executed on call successed.
+onerror | optional | An array of Behavior Actions to be executed on call failed.
 
 ---
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -838,20 +838,22 @@ Behavior Action `for` is a control flow statement for specifying iteration, whic
 
 For example:
 ```json
- { "host" : "for",
-   "from": 0,
-   "to": 3,
-   "do" : [
+{
+  "host" : "for", "from": 0, "to": 3,
+  "do" : [
        { "host" : "debugLog", "value" : "test" }
-   ] },
-
- { "host" : "for",
-   "value": { "key": "i" },
-   "from": 0,
-   "to": { "key": "ta" },
-   "do" : [
-       { "host" : "debugLog", "value" : { "key": "i" } }
-   ] },
+  ]
+},
+{
+  "host" : "for", "value": { "key": "i" }, "from": 0, "to": { "key": "ta" },
+  "do" : [
+    { "host" : "debugLog", "value" : { "key": "i" } },
+    {
+      "host": "if", "expression": {">=": [{"key": "i"}, 10]},
+      "then": [{"host": "break"}]
+    }
+  ]
+},
 ```
 
 Parameter | DescriptionG

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -183,7 +183,7 @@ Behavior actions take various values as input to their actions. There are 3 type
 2 - Stored Values
 3 - Expressions
 
-*NOTE:* Boolean values are used as literals for attributes (e.g. a `Text` element's `wrap` attribute) and 
+NOTE: Boolean values are used as literals for attributes (e.g. a `Text` element's `wrap` attribute) and 
 in expressions like in the `if` host action. When non-boolean values are used where a boolean value is expected, they
 are evaluated in a "truthy" manner according to the following rules:
 * false values are: `false`, 0, `null`, `undefined`, "", and "false".

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -322,6 +322,7 @@ The `return` host action can be used to return from the function immediately.
 Local variable values can be assigned via the `local` assign action. Such variables exist only during the current invocation's execution.
 
 <summary>For example:</summary>
+
 ```json
 {
   "elements": [...],

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -161,22 +161,15 @@ Local variable values can be assigned via the `local` assign action. Such variab
   "elements": [...],
   "functions": {
     "testFunction": [
-      {"host": "assign", "local": "v", "value": {"arg": "x"}}
+      {"host": "assign", "local": "v", "value": {"arg": "x"}},
       {"host": "return", "value": {"+": [{"local": "v"}, {"local": "v"}]}}
     ]
   },
   "behaviors": {
     "testButton": {
       "appear": [
-        {
-	  "host": "invoke",
-	  "function": "testFunction",
-	  "args": {"x": 123}
-	},
-        {
-	  "host": "debugLog",
-	  "value": {"invoke": "testFunction", "args": {"x": 123}}
-	}
+        {"host": "invoke", "function": "testFunction", "args": {"x": 123}},
+        {"host": "debugLog", "value": {"invoke": "testFunction", "args": {"x": 123}}}
       ]
     }
   }
@@ -200,7 +193,7 @@ Behavior actions take various values as input to their actions. There are 3 type
 
 *NOTE:* Boolean values are used as literals for attributes (e.g. a `Text` element's `wrap` attribute) and 
 in expressions like in the `if` host action. When non-boolean values are used where a boolean value is expected, they
-are evaluated in a "truthy" manner accordnig to the following rules:
+are evaluated in a "truthy" manner according to the following rules:
 * false values are: `false`, 0, `null`, `undefined`, "", and "false".
 * true values are `true`, 1, and in fact any value that is not a false value.
 * in particular, non-null object and array values are evaluated as `true` in boolean contexts.
@@ -362,7 +355,9 @@ now recommended, as shown with the examples below:
 
 #### Misc Expressions
 ```json
-{ "host" : "debugLog", "value" : {"element": "button1", "attribute": "image_url"} },
+{ "host" : "debugLog", "value" : {"element": "button1", "attribute": "image_url"} }, // element attributes
+
+{"host": "debugLog", "value": {"invoke": "testFunction", "args": {"x": 123}}},
 
 { "host" : "debugLog", "value" : {"random": 10 } },                // random 0 to 9, excluding 10
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -775,9 +775,10 @@ Triggers the "Return to Content" button, exiting the ad flow for a completed ad.
 
 Navigates to a different BlueScript step, pushing the new step onto the navigational stack. A viewer is able to get back to the previous step using the BACK key or equivalent.
 
-Parameter | Description
---- | ---
-cardName | Name of the step to transition to, as defined in the top level list of BlueScript steps.
+Parameters:
+
+|   |   |
+| cardName | Name of the step to transition to, as defined in the top level list of BlueScript steps.
 
 ##### (3) - `replaceStep`
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -952,12 +952,12 @@ For example:
 }
 ```
 
-Parameter | Default | Description foo
+Parameter | Default | Description
 --- | --- | ---
 url | (required) | The server/file location.
 method | "GET" | one of "GET", "PUT", "POST", "DELETE", "HEAD"
-headers | { "Accept": "application/json", "Content-Type": "application/json" } | object map of header names to values, defaults
-body | null | if present, sent as the body of the request for PUT and POST requests. Strings are sent as is, objects converted to form encoding for "application/x-www-form-urlencoded" content type requests, JSON otherwise.
+headers | {<br/>"Accept": "application/json",<br/>>"Content-Type": "application/json" } | object map of header names to values, defaults
+body | null | if present, sent as the body of the request for PUT and POST requests.<br/>Strings are sent as is, objects converted to form encoding for "application/x-www-form-urlencoded" content type requests, JSON otherwise.
 assignResponseTo | optional | takes a `key` or `local` variable reference, to be assigned the returned string/json response.
 responseAsJson | false | will try to parse the return as JSON before applying the response
 onload | optional | An array of Behavior Actions to be executed on call successed.

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -953,7 +953,7 @@ For example:
 ```
 
 Parameter | Default | Description
---- | ---
+--- | --- | ---
 url | (required) | The server/file location.
 method | "GET" | one of "GET", "PUT", "POST", "DELETE", "HEAD"
 headers | { "Accept": "application/json", "Content-Type": "application/json" } | object map of header names to values, defaults

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -32,8 +32,8 @@ _rev. 2021-09-10
 1. [BlueScript Behaviors](#bluescript-behavior-reference)
    1. [Events](#behavior-events)
    1. [Actions](#behavior-actions)
-1. [Authoring Considerations](#authoring-considerations)
-   1. [Memory Management](#memory-management)
+1. [Roku Authoring Considerations](#roku-authoring-considerations)
+   1. [Roku Memory Management](#roku-memory-management)
 
 ## 1 Overview
 
@@ -1135,11 +1135,11 @@ value | | A value to use for the event, if appropriate.
 
 ---
 
-## Authoring Considerations
+## Roku Authoring Considerations
 
 This section documents additional considerations to take into account when authoring creatives for the Roku platform using BlueScript.
 
-### Memory Management
+### Roku Memory Management
 
 Roku devices have limited memory available to load and display images. Compounding the problem is the fact that Roku stores images in uncompressed form, so that a loaded image takes up WIDTH x HEIGHT x 4 bytes, regardless of its size on disk. On lower end devices, this can be problematic, and rather than cause a critical error, exceeding this limit leads to flickering and other artifacts as the Roku system aggressively cycles images in and out of texture memory. This is all documented in [detail here](https://developer.roku.com/docs/developer-program/performance-guide/memory-management.md).
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -952,7 +952,7 @@ For example:
 }
 ```
 
-Parameter | Default | Description
+Parameter | Default | Description foo
 --- | --- | ---
 url | (required) | The server/file location.
 method | "GET" | one of "GET", "PUT", "POST", "DELETE", "HEAD"

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -341,7 +341,7 @@ now recommended, as shown with the examples below:
 {"host": "assign", "local": "now", "value":  {"date":  1631316792480}}, // from timestamp
 {
   "host": "assign", "local": "nextWeek", 
-  "value": {"date": {"+": [{"local": "now.time"}, {"*": [7, 24, 60, 60, 1000]}]}} // next week
+  "value": {"date": {"+": [{"local": "now.time"}, {"*": [7, 24, 60, 60, 1000]}]}}
 },
 
 { "host": "assign", "local": "yearStart", "value":  {"date": {"year": 2021}} },

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -5,16 +5,24 @@ _rev. 2020-06-08_
 1. [Overview](#overview)
 1. [Structure](#overall-structure)
    1. [Top Level Syntax](#top-level-payload-syntax)
-   1. [Element Syntax](#basic-bluescript-element-syntax)
+   1. [Element Syntax](#bluescript-element-syntax)
    1. [Values and Expressions](#values-and-expressions)
    1. [Examples](#examples)
 1. [Element Reference](#bluescript-element-reference)
+   1. [Step](#step)
+      1. [Elements](#elements)
+      1. [Behaviors](#behaviors)
+         1. [Behavior Events](#behavior-events)
+         1. [Behavior Actions](#behavior-actions)
+      1. [Functions](#functions)
+   1. [Step](#step)
    1. [Step](#step)
    1. [Rectangle](#rectangle)
    1. [Image](#image)
    1. [Video](#video)
    1. [Label](#label)
    1. [Button](#button)
+   1. [Text](#text)
    1. [Audio](#audio)
    1. [QRCode](#qrcode)
 1. [Authoring Considerations](#authoring-considerations)
@@ -90,7 +98,7 @@ is that all host action attributes are evaluated as expressions, all operation p
 object literals that do not match any expression format are used as is.
 
 If one is unclear whether or not an object is evaluated or not, they can used the "literal" expression to force the
-unevaluated used of the value.
+unevaluated use of the value.
 
 ###### Example
 ```json
@@ -132,15 +140,15 @@ One refers to them using "local" instead of "key" in expressions, `assign`, `for
  { "host" : "debugLog", "value" : { "local": "weatherJson.properties.periods.0" } },
 ```
 
-##### (3) - Operation Expressions.
+##### (3) - Expressions.
 
-Operations are used to compare values, perform arithmetic operations, logical operations, and perform functions that return value (random, for example), given an array of `values` as input.
+Expressions are used to compare values, perform arithmetic operations, logical operations, and perform functions that return value (random, for example), given an array of `values` as input.
 
-NOTE: the older form of operation expresses was like:
+NOTE: the older form of operation expressions was like:
 ```json
 { "host" : "debugLog", "value" : {"operation": "+", "values": [123, 123] } }, 
 ```
-This form is still supported for backwards compatibility so as to not break existing ads. A simplified form is
+This form is still supported for backwards compatibility so as not to break existing ads. A simplified form is
 now recommended, as shown below.
 
 ###### Arithmetic Operations Example
@@ -169,7 +177,7 @@ now recommended, as shown below.
  { "host" : "debugLog", "value" : {"random": 10 } },
 ```
 
-###### Operation format:
+###### Expression format:
 
 {"<operation>": <values>}
 
@@ -211,7 +219,11 @@ formatMinutesSeconds | Format seconds as `MM:SS`, or `H:MM:SS` if over an hour |
 formatHoursMinutesSeconds | Format seconds as `H:MM:SS` | 1 | Number | `{"formatMinutesSeconds": 3599}` returns `"0:59:59"` | -
 ---
 
-### Basic BlueScript Element Syntax
+### Functions
+
+TBD
+
+### BlueScript Element Syntax
 
 ```json
 {
@@ -240,14 +252,14 @@ A **step** (or **card**) defines a single, self-contained screen. No two steps c
 
 Property | Default | Description
 --- | --- | ---
-name | N/A (Required) | ID(String) for the step and used to identify it for behaviors.
+name | N/A (Required) | Name (String) of the step and used to identify it for behaviors.
 elements | N/A (Required) | An array that contains elements of this step. Z-indexed by the order, the first element is on the top, the last element is at the bottom.
 behaviors | {} (Optional)| An object containing named event handlers, which define the behavior of elements, by their IDs.
 functions | {} (Optional) | An object containing named functions, which can be invoked from behavior events and other functions.
 
-#### Elements Properties
+#### Elements
 
-Elements - the BlueScript objects defined in each step - has the following properties:
+**Elements** - Defines the array of BlueScript elements that exist in each step - each element has the following properties:
 
 Property | Default | Description
 --- | --- | ---
@@ -256,7 +268,7 @@ name | N/A (Required) | Name of the element and used to identify it for behavior
 
 **Note:** More properties are available depending on the TYPE of BlueScript element, detailed per element below.
 
-#### Behaviors Properties
+#### Behaviors
 
 **Behaviors** - the **step** property that contains all behaviors for each element of the step - is an object with keys that match element names:
 * **\<NAME\>** - Name of the BlueScript element that the child behaviors are associated with
@@ -279,9 +291,7 @@ Element Name | {} | An object that defines the behavior on events. Each base beh
 ```
 </details>
 
-#### Base Behavior Properties
-
-For each event, an array of **actions** can be defined. BlueScript elements can define any number of behavior actions for any number of events.
+For each event, an array of behavior **actions** can be defined. BlueScript elements can define any number of behavior actions for any number of events.
 
 Property | Default | Description
 --- | --- | ---
@@ -302,7 +312,7 @@ behavior | [ ] | Defines the list of behavior actions to be triggered on specifi
 ```
 </details>
 
-#### Base Behavior Events
+#### Behavior Events
 
 The following are the top-level events that behaviors can be triggered from:
 
@@ -321,7 +331,7 @@ videoThirdQuartile | Triggered when 75% of the video has played.
 videoCompleted | Triggered when the video has completed playback.
 videoLooped | Triggered when the video has automatically restarted playback.
 
-#### Base Behavior Actions
+#### Behavior Actions
 
 This section details the **Behavior Actions** that are available to any BlueScript element. Actions are invoked when Events occur.
 
@@ -1054,6 +1064,12 @@ onSelect | Triggered when the button is selected.
 #### Button Behavior Actions
 
 N/A. Note: manipulating properties of the button such as `checked` can be achieved using the `setAttribute` behavior action.
+
+---
+
+### Text
+
+TBD
 
 ---
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -643,7 +643,7 @@ For example:
 }
 ```
 
-Additional Button Properties:
+Additional QRCode Properties:
 
 Property | Default | Description
 --- | --- | ---

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -24,13 +24,17 @@ _rev. 2020-06-08_
 
 We've created BlueScript as the true[X] creative format on the Roku platform since the built-in Roku SceneGraph XML cannot be dynamically served down, compiled, and instantiated. BlueScript provides us with the dynamic creative language we need to drive interactive ad experiences on behalf of our advertisers on the Roku platform.
 
-BlueScript creatives are mastered and served down by the RTB ad server as part of the `asset_args` payload of ads. The example payloads under the [`vastConfigs`](https://github.com/socialvibe/southback/tree/develop/channel_res/vastConfigs) folder in `southback` exemplify this.
+BlueScript is also present for HTML5 now as well, which allows the same ads for Roku and HTML5 to be easily created by simply copying over the same Bluescript code of the Layout JSON section.
 
-BlueScript carries forward the "step" paradigm introduced in TVML with the top level structure being a list of "steps" (or _cards_) one can navigate between. Then entry-point (first step) for true[X] ads is always `main_card`.
+For Roku, BlueScript creatives are mastered and served down by the RTB ad server as part of the `asset_args` payload of ads. The example payloads under the [`vastConfigs`](https://github.com/socialvibe/southback/tree/develop/channel_res/vastConfigs) folder in `southback` exemplify this.
 
-Each card contains a flat list of BlueScript elements. There is implied hierarchy in the elements being instantiated and added to the scene in order they are declared. Thus, earlier-declared elements will be drawn _underneath_ later-declared elements, if they occupy the same drawing region.
+For HTML5, the RTB server also serves up the ads, but the window_url in the vast config indicates the engagement web experience for display in an iframe. The engagement SDK will pull in the ad payload including the layoutJSON bluescript code. E.g. here is a [sample vast config url](https://qa-get.truex.com/15c7f5269a09bd8c5007ba98263571dd80c458e5/vast/config?dimension_2=0&dimension_5=hilton&stream_position=preroll&stream_id=1234&network_user_id=5a9f137a-51b2-4e1a-9238-0d0ecfb26c16&env[]=html) that returns a vast config. Once running, with the user selecting Yes in the choice card, the ad payload is returned via an [engagement ad vars query](http://qa-serve.truex.com/engage.json?bid_info=0-FzpTVJVASph-4KyRcZJ8ihWgMxpwC6cWtjTmPSUywE6J7g4SgxagXQyuupEotjap4aJDqirZpzXoqRMtcphcUxxoQHboxj7otPH5wute5zecvVgCxnY51PFpWgEhscpneMVZS4QSWfRDXLnHP8x1z5UfiPMVaptcLSJaJAJ8YJL67sUcti6K1vvFJzC722ZbRWTmiqDUttgLAyXBtcKM24CBxMk7vVsL122ivFn43sgEAcbczkvkgCH7u1TiT&campaign_id=4349&creative_id=8245&currency_amount=1&env%5B%5D=html&impression_signature=cb80d8784964bb0cc6b4ddade7461a2cdff5aabf0f36a6010a45041d555c135d&impression_timestamp=1630694571.2783427&initials=0&internal_referring_source=08AMYXWJZUx3OA3UYWgfWA&ip=172.218.11.127&network_user_id=91a8d3ef-e93d-4b47-93c7-3261708514b7&placement_hash=15c7f5269a09bd8c5007ba98263571dd80c458e5&referrer=http%3A%2F%2Flocalhost%3A8080%2F&session_id=kDtp3T7RTp6tcOCbOhwacA&stream_id=1234&stream_id=1234&stream_position=preroll&stream_position=preroll&user_agent=Mozilla%2F5.0%20%28Macintosh%3B%20Intel%20Mac%20OS%20X%2010_15_7%29%20AppleWebKit%2F537.36%20%28KHTML%2C%20like%20Gecko%29%20Chrome%2F92.0.4515.159%20Safari%2F537.36&vault=0-YxSoUqGhh2-2GDi8oPd6PTgP675F7ezDqrQJ8wjZ9JEMHQBKERrNS5FHVPnFni3tfQj7mxTWmebH79AsaeeYtPHfoUuP7PNuKpJ7ZPzpSV4Cmdr8FeWGg4SDe&truexdm_channel=choicecard_mobile464985&iframed.mraid=1&appId=com.truex.skyline&disableWhiteops=false&disableMoat=false&ctv=1). The Bluescript code for the add is in the `creative_json.asset_args.layout` section.
 
-BlueScript elements support event handlers, enabling dynamic behavior. These can be used to trigger a variety of supported actions, such as controlling a video or playing sound effects. This is expressed as lists of behavior actions keyed on events. See below and `southback` repo for examples of this.
+BlueScript carries forward the "step" paradigm introduced in TVML with the top level structure being a list of "steps" (or _cards_) one can navigate between. For Roku, the entry-point (first step) for true[X] ads is always `main_card`. For HTML5, this is just a convention, the first step is initially shown regardless of its name.
+
+Each step card contains a flat list of BlueScript elements. There is implied hierarchy in the elements being instantiated and added to the scene in order they are declared. Thus, earlier-declared elements will be drawn _underneath_ later-declared elements, if they occupy the same drawing region.
+
+BlueScript elements support event handlers, enabling dynamic behavior. These can be used to trigger a variety of supported actions, such as controlling a video or playing sound effects. This is expressed as lists of behavior actions keyed on events. See below and `southback` repo (for Roku) and `Skyline` repo (for HTML5) for examples of this.
 
 ## Overall Structure
 
@@ -40,28 +44,33 @@ BlueScript elements support event handlers, enabling dynamic behavior. These can
 **Schema:**
 ```json
 {
-   "steps": [
-      {
-         "name": "main_card",
-         "__comment__": "optional comment about this step",
-         "elements": [
-            "<(LIST OF BlueScript ELEMENTS (JSON OBJECTS))>"
-         ],
-         "behaviors": {
-            "<ELEMENT ID>" : {
-               "<EVENT>" : [
-                  "<(LIST OF BEHAVIOR ACTIONS TRIGGERED BY EVENT)>"
-               ]
-            }
-         }
+  "steps": [
+    {
+      "name": "main_card",
+      "__comment__": "optional comment about this step",
+      "elements": [
+      "<(LIST OF BlueScript ELEMENTS (JSON OBJECTS))>"
+      ],
+      "behaviors": {
+        "<ELEMENT ID>" : {
+          "<EVENT>" : [
+            "<(LIST OF BEHAVIOR ACTIONS TRIGGERED BY EVENT)>"
+          ]
+        }
       },
-      {
-         "name": "second_card",
-         "elements": [
-            "<(LIST OF BlueScript ELEMENTS (JSON OBJECTS))>"
-         ]
+      "functions": {
+       "<FUNCTION NAME>": [
+          "<(LIST OF BEHAVIOR ACTIONS TO RUN IN THE FUNCTION)>"
+       ]
       }
-      ...]
+    },
+    {
+      "name": "second_card",
+      "elements": [
+      "<(LIST OF BlueScript ELEMENTS (JSON OBJECTS))>"
+      ]
+    }
+    ...]
 }
 ```
 
@@ -69,16 +78,18 @@ BlueScript elements support event handlers, enabling dynamic behavior. These can
 
 ```json
 {
-   "type" : "<TYPE of the BlueScript ELEMENT, [Image](#image), [Video](#video), [Label](#label), [Button](#button), [Audio](#audio), [Rectangle](#rectangle)>",
-   "name" : "<unique STRING ID of the BlueScript ELEMENT>",
-   "__comment__": "optional comment about this element",
-   "<ADDITIONAL ELEMENT-SPECIFIC PROPERTIES>": "e.g. 'width' AND 'height'>"
+    "type" : "<TYPE of the BlueScript ELEMENT, [Image](#image), [Video](#video), [Label](#label), [Button](#button), [Audio](#audio), [Rectangle](#rectangle)>",
+    "name" : "<unique STRING ID of the BlueScript ELEMENT>",
+    "__comment__": "optional comment about this element",
+    "<ADDITIONAL ELEMENT-SPECIFIC PROPERTIES>": "e.g. 'width' AND 'height'"
 }
 ```
 
 ### Examples
 
-[See example payloads in the `southback` repo, `vastConfig` folder.](https://github.com/socialvibe/southback/tree/develop/channel_res/vastConfigs)
+For Roku: See the [example payloads](https://github.com/socialvibe/southback/tree/develop/channel_res/vastConfigs) in the `southback` repo, `vastConfig` folder.
+
+For HTML5: See the [sample-bluescript.json](https://github.com/socialvibe/truex-bluescript-js/blob/develop/src/bluescript/__tests__/sample-bluescript.json) in the `truex-bluescript` repo.
 
 ## BlueScript Element Reference
 
@@ -86,7 +97,7 @@ This section documents the base properties and behaviors inherited by all other 
 
 ### Step
 
-A **step** (or **card**) defines a single, self-contained screen. No two steps can be presented simultaneously, but a step can be cached so that its state is preserved.
+A **step** (or **card**) defines a single, self-contained screen. No two steps can be presented simultaneously. Steps are recreated afresh whenever they are displayed. The ad developer can preserve state across steps with the use of global "key variables" if they need to programmatically restore a previous visual state.
 
 #### Step Properties
 
@@ -94,7 +105,8 @@ Property | Default | Description
 --- | --- | ---
 name | N/A (Required) | ID(String) for the step and used to identify it for behaviors.
 elements | N/A (Required) | An array that contains elements of this step. Z-indexed by the order, the first element is on the top, the last element is at the bottom.
-behaviors | {} | An object, which define the behavior of elements, by their IDs.
+behaviors | {} (Optional)| An object containing named event handlers, which define the behavior of elements, by their IDs.
+functions | {} (Optional) | An object containing named functions, which can be invoked from behavior events and other functions.
 
 #### Elements Properties
 
@@ -103,23 +115,22 @@ Elements - the BlueScript objects defined in each step - has the following prope
 Property | Default | Description
 --- | --- | ---
 type | N/A (Required) | Type for the BlueScript element. See below for what is supported.
-name | N/A (Required) | ID for the element and used to identify it for behaviors.
+name | N/A (Required) | Name of the element and used to identify it for behaviors.
 
 **Note:** More properties are available depending on the TYPE of BlueScript element, detailed per element below.
 
 #### Behaviors Properties
 
-Behaviors - the **step** property that contains all behaviors for each element of the step - is an object with keys that match element IDs:
-* **\<STRING ID\>** - ID of the BlueScript element that the child behaviors are associated with
-  and has an array value that defines the behaviors of the object for each event (see below).
+**Behaviors** - the **step** property that contains all behaviors for each element of the step - is an object with keys that match element names:
+* **\<NAME\>** - Name of the BlueScript element that the child behaviors are associated with
+  and has an array value that defines the behavior "host" action of the object for each event (see below).
 
 Property | Default | Description
 --- | --- | ---
-Element ID | {} | An object that defines the behavior on events. Each base behavior contains an array of actions.
+Element Name | {} | An object that defines the behavior on events. Each base behavior contains an array of actions.
 
 <details>
 <summary>For example:</summary>
-
 ```
 {
   "behaviors": {
@@ -162,6 +173,16 @@ Behavior Event | Description
 --- | ---
 appear | Triggered when the element's parent card is displayed. Note that appear does not tie to visibility.
 disappear | Triggered when the element's parent card is dismissed, such as on a card transition or when ending the ad flow.
+onselect | Trigger when a button with the focus is clicked on or the select/enter button is pressed on the remote.
+onfocusgained | Triggered when a button gains the remote/keyboard focus.
+onfocuslost | Triggered when a button loses the remote/keyboard focus.
+timerTick | Triggered when the countdown timer updates its value. <br/> Use the `{"key": "timerTickValue"}` expression to access the current timer value.
+videoStarted | Triggered when a video starts playback.
+videoFirstQuartile | Triggered when 25% of the video has played.
+videoSecondQuartile | Triggered when 50% of the video has played.
+videoThirdQuartile | Triggered when 75% of the video has played.
+videoCompleted | Triggered when the video has completed playback.
+videoLooped | Triggered when the video has automatically restarted playback.
 
 #### Base Behavior Actions
 
@@ -169,13 +190,15 @@ This section details the **Behavior Actions** that are available to any BlueScri
 
 ##### (1) - `allDoneButtonPushed`
 
-Triggers the "Watch Your Show" button, exiting the ad flow for a completed ad.
+Triggers the "Return to Content" button, exiting the ad flow for a completed ad.
 
 ###### Parameters
 
 N/A
 
 ##### (2) - `showStep`
+
+[Deprecated: "step stacking" is no longer upported, not even available on HTML5. Use explicit `replaceStep` actions instead.]
 
 Navigates to a different BlueScript step, pushing the new step onto the navigational stack. A viewer is able to get back to the previous step using the BACK key or equivalent.
 
@@ -187,7 +210,7 @@ cardName | Name of the step to transition to, as defined in the top level list o
 
 ##### (3) - `replaceStep`
 
-Navigates to a different BlueScript step, replacing the current step on the navigational stack.
+Navigates to a different BlueScript step, replacing the current step being displayed.
 
 ###### Parameters
 
@@ -197,7 +220,8 @@ cardName | Name of the step to transition to, as defined in the top level list o
 
 ##### (4) - `resetFocus`
 
-Re-initializes the focus handler and ensures a proper control is focused.
+Re-initializes the focus handler and ensures a default control is focused, which is usually the visually top most / left most button.
+This can be set programmatically in an "appear" event handler via the `focusElement` action.
 
 ###### Parameters
 
@@ -205,7 +229,7 @@ N/A
 
 ##### (5) - `setAttribute`
 
-Assigns a new value to given property for the native component underlying the BlueScript element.
+Assigns a new value to given property for the script element, typically controlling a visual aspect of the underlying component.
 
 ###### Parameters
 
@@ -241,16 +265,19 @@ uri | Uri of the sound file to trigger playback for.
 
 On Roku, `playSoundEffect` is a wrapper on top of the [`<SoundEffect/>`](https://sdkdocs.roku.com/display/sdkdoc/SoundEffect) SceneGraph component. It is notably limited to WAV files as a format for the sound effects.
 
+On HTML5, the standard .mp3, .wav, etc. file types work.
 
 ##### (8) - `debugLog`
 
-Prints log to BrightScript terminal. (Attach ` | grep "debugLog: "` at the end of `telnet` comment to filter for `debugLog`)
+On Roku, prints a log message to BrightScript terminal. Attach ` | grep "debugLog: "` at the end of `telnet` comment to filter for `debugLog`.
+
+On HTML5, prints a log message to the browser's console log. Examine the console log of the browser the ad is running in.
 
 ###### Example
 ```json
-{ "host" : "debugLog", "value" : "This is a String." },     // Prints: This is a String.
-{ "host" : "debugLog", "value" : { "key": "keyOfValue" }  },        // Prints: what ever is in keyOfValue.
-{ "host" : "debugLog", "value" : { "operation": "+", "values": ["Plus ", "operation."] }  },        // Prints: Plus operation.
+{ "host" : "debugLog", "value" : "This is a String." }, // Prints: This is a String.
+{ "host" : "debugLog", "value" : {"key": "keyOfValue"}  }, // Prints: what ever is in keyOfValue.
+{ "host" : "debugLog", "value" : {"+": ["Plus ", "operation."]}  }, // Prints: Plus operation.
 ```
 
 ###### Parameters
@@ -272,32 +299,32 @@ The `if/else` Behavior Action is a conditional statement, which perform differen
  { "host" : "if",
    "expression" : true,
    "then" : [{  "host" : "debugLog",
-      "value" : "1) if true, print this" }] },
-{ "host" : "if",
-"expression" : false,
-"then" : [{  "host" : "debugLog",
-"value" : "1) if false, print this (should not print this)" }] },
+                "value" : "1) if true, print this" }] },
+ { "host" : "if",
+   "expression" : false,
+   "then" : [{  "host" : "debugLog",
+                "value" : "1) if false, print this (should not print this)" }] },
 
-{ "host" : "if",
-"expression" : false,
-"then" : [{  "host" : "debugLog",
-"value" : "2) if true, print this (should not print this)" }],
-"else" : [{  "host" : "debugLog",
-"value" : "2) else, print this" }] },
+ { "host" : "if",
+   "expression" : false,
+   "then" : [{  "host" : "debugLog",
+                "value" : "2) if true, print this (should not print this)" }],
+   "else" : [{  "host" : "debugLog",
+                "value" : "2) else, print this" }] },
 
-{ "host" : "if",
-"expression" : { "key": "didAchieveTrueAttention" } ,
-"then" : [{  "host" : "debugLog",
-"value" : "3) user DID achieve True[Attention]" }],
-"else" : [{  "host" : "debugLog",
-"value" : "3) user HAS NOT achieve True[Attention]" }] },
+ { "host" : "if",
+   "expression" : { "key": "didAchieveTrueAttention" } ,
+   "then" : [{  "host" : "debugLog",
+                "value" : "3) user DID achieve True[Attention]" }],
+   "else" : [{  "host" : "debugLog",
+                "value" : "3) user HAS NOT achieve True[Attention]" }] },
 
-{ "host" : "if",
-"expression" :  {"operation": "==", "values": [{ "key": "myObject.txLogLevel" }, 3] },
-"then" : [{  "host" : "debugLog",
-"value" : "4) txLogLevel is 3" }],
-"else" : [{  "host" : "debugLog",
-"value" : "4) txLogLevel is not 3" }] }
+ { "host" : "if",
+   "expression" :  {"==": [{ "key": "myObject.txLogLevel" }, 3] },
+   "then" : [{  "host" : "debugLog",
+                "value" : "4) txLogLevel is 3" }],
+   "else" : [{  "host" : "debugLog",
+                "value" : "4) txLogLevel is not 3" }] }
 ```
 
 ###### Parameters
@@ -314,7 +341,7 @@ There is no `else if` as of now.
 
 ##### (10) - `for`
 
-Behavior Action `for` is a control flow statement for specifying iteration, which allows Behavior Actions to be executed repeatedly. Requires a control variable with `from` and `to` values, and a `do` Behavior Actions Array.
+Behavior Action `for` is a control flow statement for specifying iteration, which allows Behavior Actions to be executed repeatedly. Requires a control variable with `from` and `to` values, and a `do` Behavior Actions Array. An optional `value` can be used to specified a "key" or "local" variable to assign the loop value to.
 
 ###### Example
 ```json
@@ -322,18 +349,16 @@ Behavior Action `for` is a control flow statement for specifying iteration, whic
    "from": 0,
    "to": 3,
    "do" : [
-      { "host" : "debugLog",
-         "value" : "test" }
+       { "host" : "debugLog", "value" : "test" }
    ] },
 
-{ "host" : "for",
-"value": { "key": "i" },
-"from": 0,
-"to": { "key": "ta" },
-"do" : [
-{ "host" : "debugLog",
-"value" : { "key": "i" } }
-] },
+ { "host" : "for",
+   "value": { "key": "i" },
+   "from": 0,
+   "to": { "key": "ta" },
+   "do" : [
+       { "host" : "debugLog", "value" : { "key": "i" } }
+   ] },
 ```
 
 ###### Parameters
@@ -341,13 +366,13 @@ Behavior Action `for` is a control flow statement for specifying iteration, whic
 Parameter | Description
 --- | ---
 value | (optional) Value Object variable that the counter should save to. Default `{ "key": "forI" }`
-from | An interger value that the loop counter would start from (could be Value Object)
-to | An interger value that the loop counter would count to (inclusive) (could be Value Object)
+from | An integer value that the loop counter would start from (could be Value Object)
+to | An integer value that the loop counter would count to (inclusive) (could be Value Object)
 do | An array of Behavior Actions that should be executed
 
 ###### Notes
 
-There's no way to break out of a loop early just as of writing of this doc (_aka `break` keyword in C-based languages_)
+One can break out of the loop via a `break` action, or even a `return` action to exist the current event handler or function entirely.
 
 ##### (11) - `assign`
 
@@ -358,16 +383,16 @@ Behavior Action `assign` is an assignment statement that sets and/or re-sets the
  { "host" : "assign",
    "key" : "i",
    "value" : 0 },
-{ "host" : "assign",
-"key" : "i",
-"value" : { "operation": "+", "values": [{ "key": "i" }, 1] } },
-{ "host" : "assign",
-"key" : "object.array.0",
-"value" : "Hello World" },
-{ "host" : "assign",
-"key" : { "operation": "+", "values": ["object.array.", { "key": "i" } ] ,
-"value" : { "key": "i" }},
-}
+ { "host" : "assign",
+   "key" : "i",
+   "value" : { "+": [{ "key": "i" }, 1] } },
+ { "host" : "assign",
+   "key" : "object.array.0",
+   "value" : "Hello World" },
+ { "host" : "assign",
+   "key" : { "+": ["object.array.", { "key": "i" } ] ,
+   "value" : { "key": "i" }},
+ }
 ```
 
 ###### Parameters
@@ -385,7 +410,8 @@ Parameter | Description
 --- | ---
 `host.ad` | Json object of the selected ad (Roku only, not supported on HTML5 yet)
 `host.tagRotationRandom` | A fixed, random number from 0-1 per instance for (video) rotation. Ad author is supposed to read this number and change their ad accordingly.
-`host.adParameters` | Contains all the adParameters and can be accessed by key.  EG.  host.adParameters.some_key
+`host.adParameters` | Contains all the adParameters from Truex Exchange and can be accessed by key.  EG. `host.adParameters.some_key`
+`host.allVars` | Contains all of the ad variables queries from the RTB server. EG. `host.allVars.locationJSON.country_code`
 `host.rotationVideos` | An object with numerous subproperties related to the set of rotation videos
 `host.rotationVideos.<0-N>` to get a specific video with that index (key: video_1 corresponds to `.0`)
 `host.rotationVideos.length` to get the number of rotational videos
@@ -406,8 +432,7 @@ Behavior Action `setTimeout` allows execution of a set of Behavior Actions at sp
 ```json
  { "host" : "setTimeout",
    "duration" : 3,
-   "do": [ { "host" : "debugLog",
-      "value" : "timeout fired after 3 seconds" } ] }
+   "do": [ { "host" : "debugLog", "value" : "timeout fired after 3 seconds" } ] }
 ```
 
 ###### Parameters
@@ -438,8 +463,8 @@ Enables Behavior Actions to read the HTTP values sent by a client during a Web r
    "responseAsJson": true,
    "assignResponseTo": { "key": "weatherJson" },
    "onload": [
-      { "host" : "debugLog",
-         "value" : { "key": "weatherJson.properties.periods.0" } } ] }
+             { "host" : "debugLog",
+               "value" : { "key": "weatherJson.properties.periods.0" } } ] }
 ```
 
 ###### Parameters
@@ -447,7 +472,7 @@ Enables Behavior Actions to read the HTTP values sent by a client during a Web r
 Parameter | Description
 --- | ---
 url | The server/file location.
-assignResponseTo | take a json with a `key` entry, which points to destination that the returned string/json will save to.
+assignResponseTo | take a json with a `key` or `local` entry, which points to variable that the returned string/json will be assigned to.
 responseAsJson | (optional, default: false) will try to parse the return as JSON before save.
 onload | An array of Behavior Actions to be executed on call successed.
 onerror | An array of Behavior Actions to be executed on call failed.
@@ -506,6 +531,8 @@ N/A
 
 ##### (21) - `popStep`
 
+[Deprecated: "step stacking" is no longer supported, not even available on HTML5. Use explicit `replaceStep` actions instead.]
+
 Removes the current BlueScript step from the stack, replacing it with the next step on the navigational stack.
 
 ##### Parameters
@@ -535,13 +562,13 @@ More than one attribute can be animated with one call to `animateElement`.
  { "host": "animateElement",
    "name": "Video_Player",
    "attributes": {
-      "x": 110,
-      "y": 217,
-      "width": 1150,
-      "height": 647
+        "x": 110,
+        "y": 217,
+        "width": 1150,
+        "height": 647
    },
    "duration": 0.5
-}
+ }
 ```
 
 ##### (23) - `trackCustomEvent`
@@ -576,9 +603,9 @@ value | | A value to use for the event, if appropriate.
 ### Value Object
 
 The variable Behavior Actions take as input. There are 3 types:
-1 - Simple Values
+1 - Literal Values
 2 - Stored Values
-3 - Operations
+3 - Expressions
 
 ##### (24) - `setBounds`
 
@@ -598,29 +625,38 @@ height |  | new height of element
 
 All new values are optional by excluding them in the action.  For example, if you only want to change x,y and leave width,height alone.
 
-##### (1) - Simple Values
+##### (1) - Literal Values
 
-The basic variables like String, Boolean, or Number
+The basic values supported by the JSON format: like String, Boolean, or Number, object literals, arrays.
+
+Note that arrays are evaluated as expressions, objects may or may not be depending on where it is used. The general rule
+is that all host action attributes are evaluated as expressions, all operation parameters are evaluated as expressions,
+object literals that do not match any expression format are used as is.
+
+If one is unclear whether or not an object is evaluated or not, they can used the "literal" expression to force the
+unevaluated used of the value.
 
 ###### Example
 ```json
- { "host" : "debugLog",
-   "value" : "this is a string" },
-{ "host" : "debugLog",
-"value" : 1234.56 },
-{ "host" : "debugLog",
-"value" : true },
+ { "host" : "debugLog", "value" : "this is a string" },
+ { "host" : "debugLog", "value" : 1234.56 },
+ { "host" : "debugLog", "value" : true },
+ { "host" : "assign", "key": "testObject", "value" : {"this": "this value", "that": "that value"} },
+ { "host" : "assign", "key": "testArray", "value" : [1, 2, 3] },
+ { "host" : "assign", "key": "testArray2", "value" : [1, 2, {"+": [3, 4]}] }, // final element is 7
+ { "host" : "assign", "key": "testObject2", "value" : {"key": "testObject"} }, // testObject's value is used
+ { "host" : "assign", "key": "testObject3", "value" : {"literal": {"key": "testObject"} } },
+ { "host" : "debugLog", "value" : {"key": "testObject3.key"} } , // outputs "testObject" string
 ```
 
-##### (2) - Stored Values
+##### (2) - Global Stored Values
 
-The local variables stored in the Behavior Action sandbox.
+The global key variables stored in the Behavior Action sandbox.
 
 ###### Example
 ```json
-{ "host" : "debugLog", "value" : { "key": "weatherJson" } },
-{ "host" : "debugLog",
-  "value" : { "key": "weatherJson.properties.periods.0" } },
+ { "host" : "debugLog", "value" : { "key": "weatherJson" } },
+ { "host" : "debugLog", "value" : { "key": "weatherJson.properties.periods.0" } },
 ```
 
 ###### Parameters
@@ -629,82 +665,94 @@ Parameter | Description
 --- | ---
 key | Name of variable. It can be a dot seperated list to indicate variable inside objects, or array. (could be another Value Object)
 
-##### (3) - Operations
+##### (2) - Local Values
+
+Local variables are like key variables, except the scope is limited to the current event handler or function invocation.
+One refers to them using "local" instead of "key" in expressions, `assign`, `for`, and `makeWebRequest` actions.
+
+###### Example
+```json
+ { "host" : "debugLog", "value" : { "local": "weatherJson" } },
+ { "host" : "debugLog", "value" : { "local": "weatherJson.properties.periods.0" } },
+```
+
+##### (3) - Operation Expressions.
 
 Operations are used to compare values, perform arithmetic operations, logical operations, and perform functions that return value (random, for example), given an array of `values` as input.
 
+NOTE: the older form of operation expresses was like:
+```json
+{ "host" : "debugLog", "value" : {"operation": "+", "values": [123, 123] } }, 
+```
+This form is still supported for backwards compatibility so as to not break existing ads. A simplified form is
+now recommended, as shown below.
+
 ###### Arithmetic Operations Example
 ```json
- { "host" : "debugLog",
-   "value" : {"operation": "+", "values": [123, 123] } },
-{ "host" : "debugLog",
-"value" : {"operation": "+", "values": [1, 2, 3] } },
-{ "host" : "debugLog",
-"value" : {"operation": "+", "values": [1,  {"operation": "*", "values": [2, 3] } ] } },
+ { "host" : "debugLog", "value" : {"+": [123, 123] } },
+ { "host" : "debugLog", "value" : {"+": [1, 2, 3] } },
+ { "host" : "debugLog","value" : {"+": [1,  {"*": [2, 3] } ] } },
 ```
 
 ###### String Operations Example
 ```json
+ { "host" : "debugLog", "value" : {"+": ["string", 123] } },
  { "host" : "debugLog",
-   "value" : {"operation": "+", "values": ["string", 123] } },
-{ "host" : "debugLog",
-"value" : "input: replace(\"This is a badass.\", \"badass\", \"awesome\")" },
+   "value" : {"replace": ["This is a badass.", "badass", "awesome"]}},
 ```
 
 ###### Comparison Operations Example
 ```json
- { "host" : "debugLog",
-   "value" : {"operation": "&&", "values": [true, false] } },
-{ "host" : "debugLog",
-"value" : {"operation": "||", "values": [true, false] } },
-{ "host" : "debugLog",
-"value" : {"operation": "!", "values": [true] } },
+ { "host" : "debugLog", "value" : {"&&": [true, false] } },
+ { "host" : "debugLog", "value" : {"||": [true, false] } },
+ { "host" : "debugLog", "value" : {"!": true } },
 ```
 
 ###### Functions Operations Example
 ```json
- { "host" : "debugLog",
-   "value" : {"operation": "random", "values": [10] } },
+ { "host" : "debugLog", "value" : {"random": 10 } },
 ```
 
-###### Parameters
+###### Operation format:
 
-Parameter | Description
---- | ---
-operation | Name of operation.
-values | An array of Simple Values, or Value Object as input. Like Polish notation, operator comes before the values; however, Operations will only take 1 operation at a time.
+{"<operation>": <values>}
+
+Where we have:
+operation | One of the operator strings from the Operator table below.
+values | An array of simple values or expressions, or a single value object as input it the operation takes a single parameter.
 
 ###### Operation
 Operator | Description | Number of input | Input type | Example | Means
 -------  | ----------- | --------------- | ---------- | ------- | -----
-\+ | Addition | >=2 | Number | `{"operation": "+", "values": [123, 123] }` | 123 + 123
-\+ | Concatenate String | >=2 | String | `{"operation": "+", "values": ["hello", "_world"] }` | "hello" + "\_world"
-\- | Subtraction | >=2 | Number | `{"operation": "-", "values": [123, 1, 23] }` | 123 - 1 - 23
-\* | Multiplication | >=2 | Number | `{"operation": "*", "values": [123, 2] }` | 123 \* 2
-/ | Division | >=2 | Number | `{"operation": "/", "values": [123, 2] }` | 123 / 2
-% | Modulus (division remainder) | 2 | Number | `{"operation": "%", "values": [123, 2] }` | 123 % 2
-== | Equal to | 2 | String, Number, or Boolean | `{"operation": "==", "values": [123, 2] }` | 123 == 2
-!= | Not equal | 2 | String, Number, or Boolean | `{"operation": "!=", "values": [123, 2] }` | 123 != 2
-\> | Greater than | 2 | Number | `{"operation": ">", "values": [123, 2] }` | 123 > 2
-< | Less than | 2 | Number | `{"operation": "<", "values": [123, 2] }` | 123 < 2
-\>= | Greater than or equal to | 2 | Number | `{"operation": ">=", "values": [123, 2] }` | 123 >= 2
-<= | Less than or equal to | 2 | Number | `{"operation": "<=", "values": [123, 2] }` | 123 <= 2
-&& | And | 2 | Boolean | `{"operation": "&&", "values": [true, false] }` | true && false --> (false)
-\|\| | Or | 2 | Boolean | `{"operation": "\|\|", "values": [true, false] }` | true \|\| false --> (true)
-! | Not | 1 | Boolean | `{"operation": "!", "values": [true] }` | !true --> (false)
-replace | String replace | 3 | String | `{"operation": "replace", "values": ["Original String to Replace", "Replace", "Modify"] }` | "Original String to Replace".replace("Replace", "Modify")
-random | Random number | 1 | Number | `{"operation": "random", "values": [10] }` | random(10)
-length | Length | 1 | Natural | `{"operation": "length", "values": ["abcde"] }` | "abcde".length()
-max | Maximum | >=2 | Number | `{"operation": "max", "values": [1, 2] }` | max(1, 2)
-min | Minimum | >=2 | Number | `{"operation": "min", "values": [1, 2] }` | min(1, 2)
-floor | Floor | 1 | Number | `{"operation": "floor", "values": [1.5] }` | Math.floor(1.5)
-ceil | Ceiling | 1 | Number | `{"operation": "ceil", "values": [1.5] }` | Math.ceil(1.5)
-round | Round | 1 | Number | `{"operation": "round", "values": [1.5] }` | Math.round(1.5)
-toFixed | Shows specified # of digits after the decimal point | 2 | Number | `{"operation": "toFixed", "values": [3.1415, 3]}` returns `"3.142"` | (3.1415).toFixed(3)
-toTrimFixed | Like {toFixed}, but also strips trailing zeroes | 2 | Number | `{"operation": "toTrimFixed", "values": [2.000001, 4]}` returns `"2"` | Number((2.000001).toFixed(4)).toString()
-zeroFill | Fill number with leading 0s | 2 | Number | `{"operation": "zeroFill", "values": [123, 5]}`  returns `"00123"` | "00" + (123).toString()
-formatMinutesSeconds | Format seconds as `MM:SS`, or `H:MM:SS` if over an hour | 1 | Number | `{"operation": "formatMinutesSeconds", "values": [3599]}` returns `"59:59"` | -
-formatHoursMinutesSeconds | Format seconds as `H:MM:SS` | 1 | Number | `{"operation": "formatMinutesSeconds", "values": [3599]}` returns `"0:59:59"` | -
+\+ | Addition | >=2 | Number | `{"+": [123, 123] }` | 123 + 123
+\+ | Concatenate String | >=2 | String | `{"+": ["hello", "_world"] }` | "hello" + "\_world"
+\- | Subtraction | >=2 | Number | `{"-": [123, 1, 23] }` | 123 - 1 - 23
+\* | Multiplication | >=2 | Number | `{"*": [123, 2] }` | 123 \* 2
+/ | Division | >=2 | Number | `{"/": [123, 2] }` | 123 / 2
+% | Modulus (division remainder) | 2 | Number | `{"%": [123, 2] }` | 123 % 2
+== | Equal to | 2 | String, Number, or Boolean | `{"==": [123, 2] }` | 123 == 2
+!= | Not equal | 2 | String, Number, or Boolean | `{"!=": [123, 2] }` | 123 != 2
+\> | Greater than | 2 | Number | `{">": [123, 2] }` | 123 > 2
+< | Less than | 2 | Number | `{"<": [123, 2] }` | 123 < 2
+\>= | Greater than or equal to | 2 | Number | `{">=": [123, 2] }` | 123 >= 2
+<= | Less than or equal to | 2 | Number | `{"<=": [123, 2] }` | 123 <= 2
+&& | And | 2 | Boolean | `{"&&": [true, false] }` | true && false --> (false)
+\|\| | Or | 2 | Boolean | `{"\|\|": [true, false] }` | true \|\| false --> (true)
+! | Not | 1 | Boolean | `{"!": true }` | !true --> (false)
+replace | String replace | 3 | String | `{"replace": ["Original String to Replace", "Replace", "Modify"] }` | "Original String to Replace".replace("Replace", "Modify")
+random | Random number | 1 | Number | `{"random": 10 }` | random(10)
+length | Length | 1 | Natural | `{"length": "abcde" }` | "abcde".length
+length | Length | 1 | Natural | `{"length": [[1, 2, 3]] }` | [1,2,3].length
+max | Maximum | >=2 | Number | `{"max": [1, 2] }` | max(1, 2)
+min | Minimum | >=2 | Number | `{"min": [1, 2] }` | min(1, 2)
+floor | Floor | 1 | Number | `{"floor": 1.5 }` | Math.floor(1.5)
+ceil | Ceiling | 1 | Number | `{"ceil": 1.5 }` | Math.ceil(1.5)
+round | Round | 1 | Number | `{"round": 1.5 }` | Math.round(1.5)
+toFixed | Shows specified # of digits after the decimal point | 2 | Number | `{"toFixed": [3.1415, 3]}` returns `"3.142"` | (3.1415).toFixed(3)
+toTrimFixed | Like {toFixed}, but also strips trailing zeroes | 2 | Number | `{"toTrimFixed": [2.000001, 4]}` returns `"2"` | Number((2.000001).toFixed(4)).toString()
+zeroFill | Fill number with leading 0s | 2 | Number | `{"zeroFill": [123, 5]}`  returns `"00123"` | "00" + (123).toString()
+formatMinutesSeconds | Format seconds as `MM:SS`, or `H:MM:SS` if over an hour | 1 | Number | `{"formatMinutesSeconds": 3599}` returns `"59:59"` | -
+formatHoursMinutesSeconds | Format seconds as `H:MM:SS` | 1 | Number | `{"formatMinutesSeconds": 3599}` returns `"0:59:59"` | -
 
 ---
 
@@ -1149,10 +1197,10 @@ The following Roku device models are treated as low end which impacts the behavi
 Assuming there is knowledge of what the A/B experiment object looks like, all information can be accessed with the following notation: `testVariations.<key>`.  This is similar to accessing information in the `host` object.  For example, with the following variation returned from the ad:
 ```json
       "variations": {
-"truex_first_experiment": "control",
-"FAP-460": "oldTT",
-"tvml_cc_test": "T0"
-},
+        "truex_first_experiment": "control",
+        "FAP-460": "oldTT",
+        "tvml_cc_test": "T0"
+      },
 ```
 Within the Bluescript, the value of tvml_cc_test can be acquired with Bluescript such as `"value": { "key": "testVariations.tvml_cc_test" }`
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -956,7 +956,7 @@ Parameter | Default | Description
 --- | --- | ---
 url | (required) | The server/file location.
 method | "GET" | one of "GET", "PUT", "POST", "DELETE", "HEAD"
-headers | {<br/>"Accept": "application/json",<br/>>"Content-Type": "application/json" } | object map of header names to values, defaults
+headers | { "Accept": "application/json",<br/> "Content-Type": "application/json" } | object map of header names to values, defaults
 body | null | if present, sent as the body of the request for PUT and POST requests.<br/>Strings are sent as is, objects converted to form encoding for "application/x-www-form-urlencoded" content type requests, JSON otherwise.
 assignResponseTo | optional | takes a `key` or `local` variable reference, to be assigned the returned string/json response.
 responseAsJson | false | will try to parse the return as JSON before applying the response

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -685,108 +685,86 @@ videoDidExitFullscreen | Triggered when video is set back to its original size.
 This section details the behavior actions that can be scripted. Actions are invoked when Events occur, 
 or when a BlueScript function is invoked.
 
-##### `playActiveAudio`
-
-Starts or resumes playback (if currently paused) for the active audio element.
-
-##### `pauseActiveAudio`
-
-Pauses playback for the active audio element.
-
-##### `resetActiveAudio`
-
-Resets playback for the active audio element by setting the play head to the beginning.
-
-##### `stopActiveAudio`
-
-Stops playback for the active audio element.
-
-##### `playVideo`
-
-Starts or resumes playback (for a paused video) for the target video.
-
-Parameter | Description
---- | ---
-target | Name of the video to play.
-
-##### `pauseVideo`
-
-Pauses playback for the target video.
-
-Parameter | Description
---- | ---
-target | Name of the video to pause.
-
-##### `resetVideo`
-
-Resets playback for the target video by setting the play head to the beginning.
-
-Parameter | Description
---- | ---
-target | Name of the video to reset.
-
-##### `stopVideo`
-
-Stops playback for the target video.
-
-Parameter | Description
---- | ---
-target | Name of the video to stop.
-
 ##### `allDoneButtonPushed`
 
 Triggers the "Return to Content" button, exiting the ad flow for a completed ad.
 
-##### `showStep`
+---
 
-[Deprecated: "step stacking" is no longer upported, not even available on HTML5. Use explicit `replaceStep` actions instead.]
+##### `animateElement`
 
-Navigates to a different BlueScript step, pushing the new step onto the navigational stack. A viewer is able to get back to the previous step using the BACK key or equivalent.
+Animates Bluescript element attributes. This action is only supported on rendered elements (not Audio), and only with certain fields (see below).
+
+Parameter | Default | Description
+--- | --- | ---
+attributes | (required) | and object defining which attributes are to be animated; (x, y, width, height and opacity. position and size are supported legacy attributes)
+duration | 0.35 | the length of time (in seconds) it will take to play the animation
+easeFunction | `outCubic` | how the values will evolve throughout the animation duration
+optional | false | (Roku only) whether or not the animation can be ignored for low-end devices under stress
+
+###### Notes
+
+Elements attributes are animated to the specified value **from their current value**!
+
+More than one attribute can be animated with one call to `animateElement`.
+
+```json
+ { "host": "animateElement",
+   "name": "Video_Player",
+   "attributes": {
+        "x": 110,
+        "y": 217,
+        "width": 1150,
+        "height": 647
+   },
+   "duration": 0.5
+ }
+```
+
+---
+
+##### `assign`
+
+Behavior Action `assign` is an assignment statement that sets and/or re-sets the value stored in the storage denoted by a variable name (named by key); in other words, it copies a value into the variable.
+
+For example:
+```json
+ { "host" : "assign",
+   "key" : "i",
+   "value" : 0 },
+ { "host" : "assign",
+   "key" : "i",
+   "value" : { "+": [{ "key": "i" }, 1] } },
+ { "host" : "assign",
+   "key" : "object.array.0",
+   "value" : "Hello World" },
+ { "host" : "assign",
+   "key" : { "+": ["object.array.", { "key": "i" } ] ,
+   "value" : { "key": "i" }},
+ }
+```
 
 Parameter | Description
 --- | ---
-cardName | Name of the step to transition to, as defined in the top level list of BlueScript steps.
+key | Name of global variable. It can be a dot seperated list to indicate variable inside objects, or array. (could be [value or expression](#values-and-expressions))
+local | Name of a local variable. Either `key` or `local` must be specified.
+value | Value of the variable (could be an expression).
 
-##### `replaceStep`
+All globals values are maintained across step displays. Local variables are maintained during the current event handler or function invocation.
 
-Navigates to a different BlueScript step, replacing the current step being displayed.
+---
 
-Parameter | Description
---- | ---
-cardName | Name of the step to transition to, as defined in the top level list of BlueScript steps.
 
-##### `resetFocus`
+##### `bringToFront`
 
-Re-initializes the focus handler and ensures a default control is focused, which is usually the visually top most / left most button.
-This can be set programmatically in an "appear" event handler via the `focusElement` action.
-
-##### `setAttribute`
-
-Assigns a new value to given property for the script element, typically controlling a visual aspect of the underlying component.
+Changes child order of a TXElement so that it draws on top of all other views.
 
 Parameter | Description
 --- | ---
-name | Name of the BlueScript element that will have one of its underlying properties changed.
-key | Name of the underlying property to update.
-value | New value for the underlying property.
+name | Name of the node to bring to the front of the view
 
-NOTE: On Roku, `setAttribute` manipulates the SceneGraph component underlying the BlueScript element. In effect, it allows access to underlying implementation for the element. This could have adverse effects.
+---
 
-##### `flagActivityForAttention`
-
-Flags the engagement as having been interacted with, fulfilling the interaction requirement of true[ATTENTION].
-
-##### `playSoundEffect`
-
-Triggers a sound effect for playback.
-
-Parameter | Description
---- | ---
-uri | Uri of the sound file to trigger playback for.
-
-NOTES: On Roku, `playSoundEffect` is a wrapper on top of the [`<SoundEffect/>`](https://sdkdocs.roku.com/display/sdkdoc/SoundEffect) SceneGraph component. It is notably limited to WAV files as a format for the sound effects.
-
-On HTML5, the standard .mp3, .wav, etc. file types work.
 
 ##### `debugLog`
 
@@ -806,6 +784,88 @@ Parameter | Description
 value | The (string) value to print out. This can be a [Value or Expression](#values-and-expressions).
 
 NOTES: We would always try to cast any types into string.
+
+---
+
+
+##### `disableUserInput`
+
+Prevent user input from being handled.
+
+---
+
+
+##### `disableUserNavigation`
+
+Prevent user directional input from being handled.
+
+---
+
+
+##### `enableUserInput`
+
+Allow user input to be handled.
+
+---
+
+
+##### `enableUserNavigation`
+
+Allow user directional input to be handled
+
+---
+
+
+##### `flagActivityForAttention`
+
+Flags the engagement as having been interacted with, fulfilling the interaction requirement of true[ATTENTION].
+
+---
+
+
+##### `focusElement`
+
+Sets the focus to a specified button or video. onFocusGained and onFocusLost are triggered when switching focus.
+
+Parameter | Description
+--- | ---
+name | Name of the node that will capture focus
+
+---
+
+
+##### `for`
+
+Behavior Action `for` is a control flow statement for specifying iteration, which allows Behavior Actions to be executed repeatedly. Requires a control variable with `from` and `to` values, and a `do` Behavior Actions Array. An optional `value` can be used to specified a "key" or "local" variable to assign the loop value to.
+
+For example:
+```json
+ { "host" : "for",
+   "from": 0,
+   "to": 3,
+   "do" : [
+       { "host" : "debugLog", "value" : "test" }
+   ] },
+
+ { "host" : "for",
+   "value": { "key": "i" },
+   "from": 0,
+   "to": { "key": "ta" },
+   "do" : [
+       { "host" : "debugLog", "value" : { "key": "i" } }
+   ] },
+```
+
+Parameter | DescriptionG
+--- | ---
+value | (optional) Local or key variable that the counter should save to. Default `{ "key": "forI" }`
+from | An integer value that the loop counter would start from (could be [Value or Expression](#values-and-expressions))
+to | An integer value that the loop counter would count to (inclusive) (could be [Value or Expression](#values-and-expressions))
+do | An array of Behavior Actions that should be executed
+
+NOTE: One can break out of the loop via a `break` action, or even a `return` action to exist the current event handler or function entirely.
+
+---
 
 ##### `if/else`
 
@@ -852,91 +912,7 @@ else | (optional) An array of Behavior Actions that should be executed if expres
 
 NOTE: There is no `else if` as of now.
 
-##### `for`
-
-Behavior Action `for` is a control flow statement for specifying iteration, which allows Behavior Actions to be executed repeatedly. Requires a control variable with `from` and `to` values, and a `do` Behavior Actions Array. An optional `value` can be used to specified a "key" or "local" variable to assign the loop value to.
-
-For example:
-```json
- { "host" : "for",
-   "from": 0,
-   "to": 3,
-   "do" : [
-       { "host" : "debugLog", "value" : "test" }
-   ] },
-
- { "host" : "for",
-   "value": { "key": "i" },
-   "from": 0,
-   "to": { "key": "ta" },
-   "do" : [
-       { "host" : "debugLog", "value" : { "key": "i" } }
-   ] },
-```
-
-Parameter | DescriptionG
---- | ---
-value | (optional) Local or key variable that the counter should save to. Default `{ "key": "forI" }`
-from | An integer value that the loop counter would start from (could be [Value or Expression](#values-and-expressions))
-to | An integer value that the loop counter would count to (inclusive) (could be [Value or Expression](#values-and-expressions))
-do | An array of Behavior Actions that should be executed
-
-NOTE: One can break out of the loop via a `break` action, or even a `return` action to exist the current event handler or function entirely.
-
-##### `assign`
-
-Behavior Action `assign` is an assignment statement that sets and/or re-sets the value stored in the storage denoted by a variable name (named by key); in other words, it copies a value into the variable.
-
-For example:
-```json
- { "host" : "assign",
-   "key" : "i",
-   "value" : 0 },
- { "host" : "assign",
-   "key" : "i",
-   "value" : { "+": [{ "key": "i" }, 1] } },
- { "host" : "assign",
-   "key" : "object.array.0",
-   "value" : "Hello World" },
- { "host" : "assign",
-   "key" : { "+": ["object.array.", { "key": "i" } ] ,
-   "value" : { "key": "i" }},
- }
-```
-
-Parameter | Description
---- | ---
-key | Name of global variable. It can be a dot seperated list to indicate variable inside objects, or array. (could be [value or expression](#values-and-expressions))
-local | Name of a local variable. Either `key` or `local` must be specified.
-value | Value of the variable (could be an expression).
-
-All globals values are maintained across step displays. Local variables are maintained during the current event handler or function invocation.
-
-##### `setTimeout`
-
-Behavior Action `setTimeout` allows execution of a set of Behavior Actions at specified time intervals. (One time, or repeat)
-
-For example:
-```json
- { "host" : "setTimeout",
-   "duration" : 3,
-   "do": [ { "host" : "debugLog", "value" : "timeout fired after 3 seconds" } ] }
-```
-
-Parameter | Description
---- | ---
-repeat | (optional, default false) A boolean value that indicate if the timer will fire repeatedly.
-duration | `duration` indicates the number of seconds before execution. Note: we will tolerate `timeout`, or `delay`
-do | An array of Behavior Actions to be executed.
-
-###### Notes
-
-Creative is expected to stop their repeated timers.
-Currently there are no menthod to stop an individual timer.
-
-##### `stopAllTimers`
-
-The `stopAllTimers` stops the execution of all the timers specified in setTimeout(), and clear all the saved timers.
+---
 
 ##### `makeWebRequest`
 
@@ -961,37 +937,53 @@ responseAsJson | (optional, default: false) will try to parse the return as JSON
 onload | An array of Behavior Actions to be executed on call successed.
 onerror | An array of Behavior Actions to be executed on call failed.
 
-##### `bringToFront`
+---
 
-Changes child order of a TXElement so that it draws on top of all other views.
+##### `pauseActiveAudio`
+
+Pauses playback for the active audio element.
+
+---
+
+##### `pauseVideo`
+
+Pauses playback for the target video.
 
 Parameter | Description
 --- | ---
-name | Name of the node to bring to the front of the view
+target | Name of the video to pause.
 
-##### `focusElement`
+---
 
-Sets the focus to a specified button or video. onFocusGained and onFocusLost are triggered when switching focus.
+##### `playActiveAudio`
+
+Starts or resumes playback (if currently paused) for the active audio element.
+
+---
+
+##### `playSoundEffect`
+
+Triggers a sound effect for playback.
 
 Parameter | Description
 --- | ---
-name | Name of the node that will capture focus
+uri | Uri of the sound file to trigger playback for.
 
-##### `disableUserInput`
+NOTES:
+* On Roku, `playSoundEffect` is a wrapper on top of the [`<SoundEffect/>`](https://sdkdocs.roku.com/display/sdkdoc/SoundEffect) SceneGraph component. It is notably limited to WAV files as a format for the sound effects.
+* On HTML5, the standard .mp3, .wav, etc. file types work.
 
-Prevent user input from being handled.
+---
 
-##### `enableUserInput`
+##### `playVideo`
 
-Allow user input to be handled.
+Starts or resumes playback (for a paused video) for the target video.
 
-##### `disableUserNavigation`
+Parameter | Description
+--- | ---
+target | Name of the video to play.
 
-Prevent user directional input from being handled.
-
-##### `enableUserNavigation`
-
-Allow user directional input to be handled
+---
 
 ##### `popStep`
 
@@ -999,35 +991,123 @@ Allow user directional input to be handled
 
 Removes the current BlueScript step from the stack, replacing it with the next step on the navigational stack.
 
-##### `animateElement`
+---
 
-Animates Bluescript element attributes. This action is only supported on rendered elements (not Audio), and only with certain fields (see below).
+##### `replaceStep`
+
+Navigates to a different BlueScript step, replacing the current step being displayed.
+
+Parameter | Description
+--- | ---
+cardName | Name of the step to transition to, as defined in the top level list of BlueScript steps.
+
+---
+
+##### `resetActiveAudio`
+
+Resets playback for the active audio element by setting the play head to the beginning.
+
+---
+
+##### `resetFocus`
+
+Re-initializes the focus handler and ensures a default control is focused, which is usually the visually top most / left most button.
+This can be set programmatically in an "appear" event handler via the `focusElement` action.
+
+---
+
+##### `resetVideo`
+
+Resets playback for the target video by setting the play head to the beginning.
+
+Parameter | Description
+--- | ---
+target | Name of the video to reset.
+
+---
+
+##### `setAttribute`
+
+Assigns a new value to given property for the script element, typically controlling a visual aspect of the underlying component.
+
+Parameter | Description
+--- | ---
+name | Name of the BlueScript element that will have one of its underlying properties changed.
+key | Name of the underlying property to update.
+value | New value for the underlying property.
+
+NOTE: On Roku, `setAttribute` manipulates the SceneGraph component underlying the BlueScript element. In effect, it allows access to underlying implementation for the element. This could have adverse effects.
+
+---
+
+##### `setBounds`
+
+Instantly sets the bounds / position of an element.  An alternative to animateElement when duration = 0
 
 Parameter | Default | Description
 --- | --- | ---
-attributes | (required) | and object defining which attributes are to be animated; (x, y, width, height and opacity. position and size are supported legacy attributes)
-duration | 0.35 | the length of time (in seconds) it will take to play the animation
-easeFunction | `outCubic` | how the values will evolve throughout the animation duration
-optional | false | (Roku only) whether or not the animation can be ignored for low-end devices under stress
+target |  | the name of the target node
+x |  | new x position
+y |  | new y position
+width |  | new width of element
+height |  | new height of element
 
-###### Notes
+NOTES: All new values are optional by excluding them in the action.  For example, if you only want to change x,y and leave width,height alone.
 
-Elements attributes are animated to the specified value **from their current value**!
+---
 
-More than one attribute can be animated with one call to `animateElement`.
+##### `setTimeout`
 
+Behavior Action `setTimeout` allows execution of a set of Behavior Actions at specified time intervals. (One time, or repeat)
+
+For example:
 ```json
- { "host": "animateElement",
-   "name": "Video_Player",
-   "attributes": {
-        "x": 110,
-        "y": 217,
-        "width": 1150,
-        "height": 647
-   },
-   "duration": 0.5
- }
+ { "host" : "setTimeout",
+   "duration" : 3,
+   "do": [ { "host" : "debugLog", "value" : "timeout fired after 3 seconds" } ] }
 ```
+
+Parameter | Description
+--- | ---
+repeat | (optional, default false) A boolean value that indicate if the timer will fire repeatedly.
+duration | `duration` indicates the number of seconds before execution. Note: we will tolerate `timeout`, or `delay`
+do | An array of Behavior Actions to be executed.
+
+NOTES: Creative is expected to stop their repeated timers.
+Currently there are no menthod to stop an individual timer.
+
+---
+
+##### `showStep`
+
+[Deprecated: "step stacking" is no longer upported, not even available on HTML5. Use explicit `replaceStep` actions instead.]
+
+Navigates to a different BlueScript step, pushing the new step onto the navigational stack. A viewer is able to get back to the previous step using the BACK key or equivalent.
+
+Parameter | Description
+--- | ---
+cardName | Name of the step to transition to, as defined in the top level list of BlueScript steps.
+
+
+##### `stopAllTimers`
+
+The `stopAllTimers` stops the execution of all the timers specified in setTimeout(), and clear all the saved timers.
+
+---
+
+##### `stopActiveAudio`
+
+Stops playback for the active audio element.
+
+---
+
+##### `stopVideo`
+
+Stops playback for the target video.
+
+Parameter | Description
+--- | ---
+target | Name of the video to stop.
 
 ##### `trackCustomEvent`
 
@@ -1054,23 +1134,6 @@ Parameter | Default | Description
 category | `fep_roku_layout` | The tracking taxonomy category to use for the tracking call. Typically omitted so default value is used.
 name | (required) | The name of the tracking event.
 value | | A value to use for the event, if appropriate.
-
-##### `setBounds`
-
-Instantly sets the bounds / position of an element.  An alternative to animateElement when duration = 0
-
-Parameter | Default | Description
---- | --- | ---
-target |  | the name of the target node
-x |  | new x position
-y |  | new y position
-width |  | new width of element
-height |  | new height of element
-
-###### Notes
-
-All new values are optional by excluding them in the action.  For example, if you only want to change x,y and leave width,height alone.
-
 
 ---
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -741,7 +741,7 @@ For example:
 
 Parameter | Description
 --- | ---
-key | Name of global variable. It can be a dot seperated list to indicate variable inside objects, or array. (could be [value or expression](#values-and-expressions))
+key | Name of global variable. It can be a dot seperated list to indicate variable inside objects, or array. (could be [value or expression](#bluescript-values-and-expressions))
 local | Name of a local variable. Either `key` or `local` must be specified.
 value | Value of the variable (could be an expression).
 
@@ -781,7 +781,7 @@ For example:
 
 Parameter | Description
 --- | ---
-value | The (string) value to print out. This can be a [Value or Expression](#values-and-expressions).
+value | The (string) value to print out. This can be a [Value or Expression](#bluescript-values-and-expressions).
 
 NOTES: We would always try to cast any types into string.
 
@@ -861,8 +861,8 @@ For example:
 Parameter | DescriptionG
 --- | ---
 value | (optional) Local or key variable that the counter should save to. Default `{ "key": "forI" }`
-from | An integer value that the loop counter would start from (could be [Value or Expression](#values-and-expressions))
-to | An integer value that the loop counter would count to (inclusive) (could be [Value or Expression](#values-and-expressions))
+from | An integer value that the loop counter would start from (could be [Value or Expression](#bluescript-values-and-expressions))
+to | An integer value that the loop counter would count to (inclusive) (could be [Value or Expression](#bluescript-values-and-expressions))
 do | An array of Behavior Actions that should be executed
 
 NOTE: One can break out of the loop via a `break` action, or even a `return` action to exist the current event handler or function entirely.
@@ -908,7 +908,7 @@ For example:
 
 Parameter | Description
 --- | ---
-expression | Expression is a [Value or Expression](#values-and-expressions), which determines the flow of the Behavior Actions
+expression | Expression is a [Value or Expression](#bluescript-values-and-expressions), which determines the flow of the Behavior Actions
 then | An array of Behavior Actions that should be executed if expression is true
 else | (optional) An array of Behavior Actions that should be executed if expression is NOT true
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -188,17 +188,7 @@ For HTML5: See the [sample-bluescript.json](https://github.com/socialvibe/truex-
 
 ## BlueScript Values and Expressions
 
-Behavior actions take various values as input to their actions. There are 3 types:
-1 - Literal Values
-2 - Stored Values
-3 - Expressions
-
-NOTE: Boolean values are used as literals for attributes (e.g. a `Text` element's `wrap` attribute) and 
-in expressions like in the `if` host action. When non-boolean values are used where a boolean value is expected, they
-are evaluated in a "truthy" manner according to the following rules:
-* false values are: `false`, 0, `null`, `undefined`, "", and "false".
-* true values are `true`, 1, and in fact any value that is not a false value.
-* in particular, non-null object and array values are evaluated as `true` in boolean contexts.
+Behavior actions take various values as input to their actions. There are 3 types: Literal Values, Stored Values, and Expressions.
 
 ### Literal Values
 
@@ -209,8 +199,15 @@ Note that arrays are evaluated as expressions, objects may or may not be dependi
 is that all host action attributes are evaluated as expressions, all operation parameters are evaluated as expressions,
 object literals that do not match any expression format are used as is.
 
-If one is unclear whether or not an object is evaluated or not, they can used the "literal" expression to force the
+If one is unclear whether or not an object is evaluated or not, they can use the "literal" expression to force the
 unevaluated use of the value.
+
+NOTE: Boolean values are used as literals for attributes (e.g. a `Text` element's `wrap` attribute) and
+in expressions like in the `if` host action. When non-boolean values are used where a boolean value is expected, they
+are evaluated in a "truthy" manner according to the following rules:
+* false values are: `false`, 0, `null`, `undefined`, "", and "false".
+* true values are `true`, 1, and in fact any value that is not a false value.
+* in particular, non-null object and array values are evaluated as `true` in boolean contexts.
 
 For example:
 ```json

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -841,7 +841,7 @@ For example:
 {
   "host" : "for", "from": 0, "to": 3,
   "do" : [
-       { "host" : "debugLog", "value" : "test" }
+       { "host" : "debugLog", "value" : {"+": ["counter is: ", {"key": "forI"}]} }
   ]
 },
 {

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -514,7 +514,7 @@ For example:
    "y"         : "150",
    "width"     : "800",
    "height"    : "0",
-   "text"      : "This is the TXAudio Tester"
+   "text"      : "This is some sample text"
 }
 ```
 
@@ -757,11 +757,11 @@ If not current executing a `for` loop, a script error is thrown.
 
 ##### `bringToFront`
 
-Changes child order of a TXElement so that it draws on top of all other views.
+Changes child order of a script element so that it draws on top of all other displayed elements.
 
 Parameter | Description
 --- | ---
-name | Name of the node to bring to the front of the view
+name | Name of the element to bring to the front of the view
 
 ---
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -1,7 +1,7 @@
 # BlueScript Documentation
 _rev. 2021-09-10
 
-## Table of Contents
+## 1 Table of Contents 1
 1. [Overview](#overview)
 1. [Structure](#overall-structure)
    1. [Top Level Syntax](#top-level-syntax)
@@ -26,7 +26,7 @@ _rev. 2021-09-10
 1. [Authoring Considerations](#authoring-considerations)
    1. [Memory Management](#memory-management)
 
-## Overview
+## 1 Overview
 
 We've created BlueScript as the true[X] creative format on the Roku platform since the built-in Roku SceneGraph XML cannot be dynamically served down, compiled, and instantiated. BlueScript provides us with the dynamic creative language we need to drive interactive ad experiences on behalf of our advertisers on the Roku platform.
 
@@ -42,9 +42,9 @@ Each step card contains a flat list of BlueScript elements. There is implied hie
 
 BlueScript elements support event handlers, enabling dynamic behavior. These can be used to trigger a variety of supported actions, such as controlling a video or playing sound effects. This is expressed as lists of behavior actions keyed on events. See below and `southback` repo (for Roku) and `Skyline` repo (for HTML5) for examples of this.
 
-## Overall Structure
+## (1) Overall Structure 1
 
-### Top Level Syntax
+### (1) Top Level Syntax 1.1
 > _**Formatting note**: strings inside of carets (`"< ... >"`) are meta-descriptions, not absolute values_
 
 **Schema:**
@@ -80,34 +80,32 @@ BlueScript elements support event handlers, enabling dynamic behavior. These can
 }
 ```
 
-### Step
+### (1)(1) Step 1.1
 
 A **step** (or **card**) defines a single, self-contained screen. No two steps can be presented simultaneously.
 Steps are recreated afresh whenever they are displayed. The ad developer can preserve state across steps with
 the use of global "key variables" if they need to programmatically restore a previous visual state.
 
-#### Step Properties
-
-Property | Default | Description
+Step Property | Default | Description
 --- | --- | ---
 name | N/A (Required) | Name (String) of the step and used to identify it for behaviors.
 elements | N/A (Required) | An array that contains [elements](#bluescript-element-reference) of this step. Z-indexed by the order, the first element is on the top, the last element is at the bottom.
 behaviors | {} (Optional)| An object containing [named event handlers](#behavior-events), which define the behavior of elements, by their element names.
 functions | {} (Optional) | An object containing named functions, which can be invoked from behavior events and other functions.
 
-#### Elements
+### Elements
 
-**Elements** - Defines the array of BlueScript elements that exist in each step - each element has the following properties:
+A step's "elements" defines the array of BlueScript visual elements that are to be displayed in each step - each element has the following properties:
 
-Property | Default | Description
+Element Property | Default | Description
 --- | --- | ---
-type | N/A (Required) | Type for the BlueScript element. See below for what is supported.
+type | N/A (Required) | Type for the BlueScript element. See [possible element types below](#bluescript-element-reference) for what is supported.
 name | N/A (Required) | Name of the element and used to identify it for behaviors.
 
 **Note:** More properties are available depending on the TYPE of BlueScript element, detailed in 
 the [element reference](#bluescript-element-reference) section.
 
-#### Behaviors
+### Behaviors
 
 A step's "behaviors" property contains all behaviors for each element of the step - is an object with keys that match element names:
 * **\<NAME\>** - Name of the BlueScript element that the child behaviors are associated with
@@ -136,7 +134,7 @@ behavior | {} | Defines the list of [behavior actions](#behavior-actions) to be 
 }
 ```
 
-#### Functions
+### Functions
 
 A step's "functions" property contains all reusable functions, keyed by function name, that can be called from other event action execution, expressions, and even other functions.
 
@@ -185,14 +183,15 @@ For HTML5: See the [sample-bluescript.json](https://github.com/socialvibe/truex-
 
 ## BlueScript Values and Expressions
 
-There are The values behavior actions take as input. There are 3 types:
+Behavior actions take various values as input to their actions. There are 3 types:
 1 - Literal Values
 2 - Stored Values
 3 - Expressions
 
 ### Literal Values
 
-The basic values supported by the JSON format: like String, Boolean, or Number, object literals, arrays.
+The basic value typs supported by BlueScript are those of the JSON format like String, Boolean, Number, 
+object literals, arrays.
 
 Note that arrays are evaluated as expressions, objects may or may not be depending on where it is used. The general rule
 is that all host action attributes are evaluated as expressions, all operation parameters are evaluated as expressions,
@@ -217,19 +216,21 @@ For example:
 ### Stored Values
 
 Stored values are either global key variables, or local variables. Global values are available across steps, local values 
-are available only within the scope of the currently excuting event behavior, or current function invocation.
+are available only within the scope of the currently executing behavior event handler, or current function invocation.
 
-One uses the `assign` host action to set a stored value, or a `key` or `local` variable expression to access it.
+One uses the `assign` host action to set a stored value, and a `key` or `local` variable expression to access it.
 
-Note that the obj.field "dot" selection notation is support to assign to and reference sub fields of an object value. 
-The fields can refer to numbers which are then interpreted as array indices.
+Note that the obj.field "dot" selection notation can be used to assign values to and reference sub fields of an object value. 
+The fields can also refer to numbers which are then interpreted as array indices.
 
 For example:
 ```json
  { "host" : "assign", "key": "globalValue", "value":  123},
  { "host" : "debugLog", "value" : { "key": "globalValue" } },
- { "host" : "assign", "local": "localValue", "value": {"field1": 1, "field2": {"subField": [1, 2, 3]}}},
- { "host" : "debugLog", "value" : { "local": "localValue.field1.2" } },
+ { "host" : "assign", "local": "localValue", "value": {"field_1": 1, "field_2": {"subField": [1, 2, 3]}}},
+ { "host" : "debugLog", "value" : { "local": "localValue.field_1" } },
+ { "host" : "debugLog", "value" : { "local": "localValue.field1_2.subField.2" } },
+ { "host" : "assign", "local": "localValue.field_2.subField.2", "value":  4},
 ```
 
 ### Expressions.

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -488,7 +488,7 @@ loop | true | If set to true, the video will be restarted from the beginning aft
 autoplay | true | If set to true, the video will be automatically started on card display.
 replayable | false | If set to true, makes the video player focusable on playback completion, enabling replay of the video.
 mute | false | Set to true to mute the audio of the video currently playing. Set to false to restore audio.
-fullscreen | false | When toggled, the video will be animated to fullscreen, or back to window
+fullscreen | false | If set to true, the video will be animated to fullscreen size, otherwise it will return to its original size.
 zoomAnimationDuration | 0.35 | The time it takes to animated between window and fullscreen. The 0.35 is copie from tvOS TAR. (Note: must be > 0)
 easeFunction | "inOutCubic" | This string defines the animation curve. For full list of easeFunction, see: https://sdkdocs.roku.com/display/sdkdoc/Animation#Animation-Fields
 currentTime | 0 | This value is the floating point time of the current stream.  This has a margin of error of 500ms due to how position is handled.
@@ -618,7 +618,7 @@ global | false | If true, audio sticks/continues playing across step card transi
 NOTES:
 * Visual properties are not relevant for the Audio element, e.g. x, y, width, height, opacity.
 * On Roku, only a single Media node may be actively playing or buffering media at a given time. This means that it is not possible to have multiple inline videos playing concurrently or a background / ambient video with inline window windows on top. This also precludes the use of background audio playing together with a video. Any additional stream started after the first one will fail silently.
-* For the MP3 format. On the PlayStation 5 and some other platforms, MP3 is not supported. BlueScript engine will try to get the MP4 version (same location, same name) of the given audio instead. Asset Uploader in True Exchange is encoding that MP4 file automatically. Be sure to include a MP4 version of your audio file if you cannot use the Asset Uploader.
+* For the MP3 format, on the PlayStation 5 and some other platforms, MP3 is not supported. BlueScript engine will try to get the MP4 version (same location, same name) of the given audio instead. Asset Uploader in True Exchange is encoding that MP4 file automatically. Be sure to include a MP4 version of your audio file if you cannot use the Asset Uploader.
 
 Related audio actions: [playActiveAudio](#playActiveAudio), [pauseActiveAudio](#pauseActiveAudio), 
 [resetActiveAudio](#resetActiveAudio), [stopActiveAudio](#stopActiveAudio)
@@ -682,7 +682,7 @@ videoSecondQuartile | Triggered when 50% of the video has played.
 videoThirdQuartile | Triggered when 75% of the video has played.
 videoCompleted | Triggered when the video has completed playback.
 videoLooped | Triggered when the video has automatically restarted playback.
-videoDidEnterFullscreen | Triggered when the video is to fullscreen size.
+videoDidEnterFullscreen | Triggered when the video is set to fullscreen size.
 videoDidExitFullscreen | Triggered when video is set back to its original size.
 
 ### Behavior Actions

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -339,7 +339,7 @@ now recommended, as shown with the examples below:
 { "host" : "debugLog", "value" : {"local":  "now.time"} },           // 1631316792480, e.g. millis since Jan 1, 1970
 
 {"host": "assign", "local": "now", "value":  {"date":  1631316792480}}, // from timestamp
-{"host": "assign", "local": "millsPerWeek", "value": {"*": [7, 24, 60, 60, 1000]}},
+{"host": "assign", "local": "millisPerWeek", "value": {"*": [7, 24, 60, 60, 1000]}},
 {
   "host": "assign", "local": "nextWeek", 
   "value": {"date": {"+": [{"local": "now.time"}, {"local": "millisPerWeek"}]}}

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -663,7 +663,7 @@ The following are the top-level events that behaviors can be triggered from:
 
 Event | Description
 --- | ---
-appear | Triggered when the element's parent card is displayed. Note that appear does not tie to visibility.
+appear | Triggered when the element's parent card is displayed. Note that appear event does not tie to the element's actual visibility.
 disappear | Triggered when the element's parent card is dismissed, such as on a card transition or when ending the ad flow.
 onSelect | Triggered when a button with the focus is clicked on or the select/enter button is pressed on the remote.
 onFocusGained | Triggered when a button or video gains the remote/keyboard focus.
@@ -700,12 +700,9 @@ duration | 0.35 | the length of time (in seconds) it will take to play the anima
 easeFunction | `outCubic` | how the values will evolve throughout the animation duration
 optional | false | (Roku only) whether or not the animation can be ignored for low-end devices under stress
 
-###### Notes
-
-Elements attributes are animated to the specified value **from their current value**!
-
-More than one attribute can be animated with one call to `animateElement`.
-
+NOTES:
+* Elements attributes are animated to the specified value **from their current value**!
+* More than one attribute can be animated with one call to `animateElement`.
 ```json
  { "host": "animateElement",
    "name": "Video_Player",

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -239,21 +239,19 @@ Certain implied global key variables always exist as read only values:
 
 Name | Description
 --- | ---
+`userHasMetTIme` | The minimum time for ad interaction has been met
+`userHasInteracted` | User has interacted with the ad
+`userHasCredit` | User has gained credit for the ad
+`timerTickValue` | Countdown remaining for the engagement ad or ChoiceCard/SkipCard
 `host.ad` | Json object of the selected ad (Roku only, not supported on HTML5 yet)
 `host.tagRotationRandom` | A fixed, random number from 0-1 per instance for (video) rotation. Ad author is supposed to read this number and change their ad accordingly.
 `host.adParameters` | Contains all the adParameters from Truex Exchange and can be accessed by key.  EG. `host.adParameters.some_key`
 `host.allVars` | Contains all of the ad variables queries from the RTB server. EG. `host.allVars.locationJSON.country_code`
 `host.rotationVideos` | An object with numerous subproperties related to the set of rotation videos
-`host.rotationVideos.<0-N>` to get a specific video with that index (key: video_1 corresponds to `.0`)
-`host.rotationVideos.length` to get the number of rotational videos
-`host.rotationVideos.currentIndex` to get the index (base 0) of the current random video
-`host.rotationVideos.currentUrl` to get the url of the current random video
-
-There are also predefined keys that provide additional information dynamically
-`userHasMetTIme` | The minimum time for ad interaction has been met
-`userHasInteracted` | User has interacted with the ad
-`userHasCredit` | User has gained credit for the ad
-`timerTickValue` | Countdown remaining (Choice/Skip Card)
+`host.rotationVideos.<0-N>` | to get a specific video with that index (key: video_1 corresponds to `.0`)
+`host.rotationVideos.length` | to get the number of rotational videos
+`host.rotationVideos.currentIndex` | to get the index (base 0) of the current random video
+`host.rotationVideos.currentUrl` | to get the url of the current random video
 
 ### Expressions
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -321,7 +321,8 @@ now recommended, as shown with the examples below:
 
 #### Date Expressions
 ```json
-{"host": "assign", "local": "now", "value":  {"date":  "now"}}, // from clock
+{"host": "assign", "local": "now", "value":  {"date": "now"}}, // from clock
+{"host": "assign", "local": "now", "value":  {"date": 1631316792480}}, // from timestamp
 {"host": "assign", "local": "now", "value":  {
    "date": {
       "year": 2021, "month":  9, "day": 10, "hours": 16, "minutes": 33, "seconds": 12, "milliseconds": 480
@@ -338,7 +339,6 @@ now recommended, as shown with the examples below:
 { "host" : "debugLog", "value" : {"local":  "now.timezoneOffset"} }, // 480
 { "host" : "debugLog", "value" : {"local":  "now.time"} },           // 1631316792480, e.g. millis since Jan 1, 1970
 
-{"host": "assign", "local": "now", "value":  {"date":  1631316792480}}, // from timestamp
 {"host": "assign", "local": "millisPerWeek", "value": {"*": [7, 24, 60, 60, 1000]}},
 {
   "host": "assign", "local": "nextWeek", 
@@ -353,22 +353,31 @@ now recommended, as shown with the examples below:
 { "host" : "debugLog", "value" : {"local": "yearStart.seconds"} }, // 0
 { "host" : "debugLog", "value" : {"local": "yearStart.time"} },    // 1612166400000
 
-{ "host": "assign", "local": "yearMo", "value":  {"date": {"year": 1999, "month": 12}} },
-{ "host" : "debugLog", "value" : {"local": "yearStart.month"} },   // 12
-{ "host" : "debugLog", "value" : {"local": "yearStart.day"} },     // 1
+{ "host": "assign", "local": "dec1999", "value":  {"date": {"year": 1999, "month": 12}} },
+{ "host" : "debugLog", "value" : {"local": "dec1999.year"} },   // 1999
+{ "host" : "debugLog", "value" : {"local": "dec1999.month"} },  // 12
+{ "host" : "debugLog", "value" : {"local": "dec1999.day"} },    // 1
+{ "host" : "debugLog", "value" : {"local": "dec1999.time"} },   // 944035200000
 ```
 
 #### Misc Expressions
 ```json
 { "host" : "debugLog", "value" : {"element": "button1", "attribute": "image_url"} },
+
 { "host" : "debugLog", "value" : {"random": 10 } },                // random 0 to 9, excluding 10
+
 { "host" : "assign", "value" : {"literal": {"random": 10}} }, // {"random": 10}, i.e. unevaluated expression
+
 { "host" : "debugLog", "value" : {"length": ["abcde"] } },           // 5
 { "host" : "debugLog", "value" : {"length": "abcde" } },           // single arg convenience
 { "host" : "debugLog", "value" : {"length": [["a", "b", "c"]] } }, // 3 ; note array args require explicit array wrapper
+
 { "host" : "debugLog", "value" : {"toFixed": [3.1415, 3]} },       // 3.142
+
 { "host" : "debugLog", "value" : {"toTrimFixed": [2.000001, 4]} }, // 2
+
 { "host" : "debugLog", "value" : {"zeroFill": [123, 5]} },         // 00123
+
 { "host" : "debugLog", "value" : {"formatMinutesSeconds": 3599} },      // "59:59"
 { "host" : "debugLog", "value" : {"formatHoursMinutesSeconds": 3599} }, // "0:59:59"
 ```

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -146,7 +146,7 @@ Arguments are passed by name, and are referred to with the function via the `arg
 
 Argument values are passed using reference semantics, matching JavaScript rules, thus objects and arrays are shared allowing for modification of subfields or elements on the shared item.
 
-Within a function, referring to arguments not in the invocation causes a script error, unless a default value is provided in the `arg` expression.
+Within a function, referring to arguments not present in the invocation causes a script error, unless a default value is provided in the `arg` expression.
 
 The `return` host action can be used to return from the function immediately.
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -1,7 +1,7 @@
-# BlueScript Documentation
+# BlueScript Reference Guide
 _rev. 2021-09-10
 
-## 1 Table of Contents 1
+## Table of Contents
 1. [Overview](#overview)
 1. [Structure](#overall-structure)
    1. [Top Level Syntax](#top-level-syntax)
@@ -80,7 +80,7 @@ BlueScript elements support event handlers, enabling dynamic behavior. These can
 }
 ```
 
-### (1)(1) Step 1.1
+### Step
 
 A **step** (or **card**) defines a single, self-contained screen. No two steps can be presented simultaneously.
 Steps are recreated afresh whenever they are displayed. The ad developer can preserve state across steps with
@@ -93,7 +93,7 @@ elements | N/A (Required) | An array that contains [elements](#bluescript-elemen
 behaviors | {} (Optional)| An object containing [named event handlers](#behavior-events), which define the behavior of elements, by their element names.
 functions | {} (Optional) | An object containing named functions, which can be invoked from behavior events and other functions.
 
-### Elements
+#### Elements
 
 A step's "elements" defines the array of BlueScript visual elements that are to be displayed in each step - each element has the following properties:
 
@@ -105,7 +105,7 @@ name | N/A (Required) | Name of the element and used to identify it for behavior
 **Note:** More properties are available depending on the TYPE of BlueScript element, detailed in 
 the [element reference](#bluescript-element-reference) section.
 
-### Behaviors
+#### Behaviors
 
 A step's "behaviors" property contains all behaviors for each element of the step - is an object with keys that match element names:
 * **\<NAME\>** - Name of the BlueScript element that the child behaviors are associated with
@@ -134,7 +134,7 @@ behavior | {} | Defines the list of [behavior actions](#behavior-actions) to be 
 }
 ```
 
-### Functions
+#### Functions
 
 A step's "functions" property contains all reusable functions, keyed by function name, that can be called from other event action execution, expressions, and even other functions.
 
@@ -188,9 +188,16 @@ Behavior actions take various values as input to their actions. There are 3 type
 2 - Stored Values
 3 - Expressions
 
+*NOTE:* Boolean values are used as literals for attributes (e.g. a `Text` element's `wrap` attribute) and 
+in expressions like in the `if` host action. When non-boolean values are used where a boolean value is expected, they
+are evaluated in a "truthy" manner accordnig to the following rules:
+* false values are: `false`, 0, `null`, `undefined`, "", and "false".
+* true values are `true`, 1, and in fact any value that is not a false value.
+* in particular, non-null object and array values are evaluated as `true` in boolean contexts.
+
 ### Literal Values
 
-The basic value typs supported by BlueScript are those of the JSON format like String, Boolean, Number, 
+The basic value types supported by BlueScript are those of the JSON format like strings, booleans, numbers, 
 object literals, arrays.
 
 Note that arrays are evaluated as expressions, objects may or may not be depending on where it is used. The general rule
@@ -237,40 +244,39 @@ For example:
 
 Expressions are used to compare values, perform arithmetic operations, logical operations, and perform functions that return value (random, for example), given an array of `values` as input.
 
-NOTE: the older form of operation expressions was like:
+*NOTE:* the older form of operation expressions was like:
 ```json
 { "host" : "debugLog", "value" : {"operation": "+", "values": [123, 123] } }, 
 ```
 This form is still supported for backwards compatibility so as not to break existing ads. A simplified form is
 now recommended, as shown below.
 
-###### Arithmetic Operations Example
+#### Arithmetic Operations Example
 ```json
  { "host" : "debugLog", "value" : {"+": [123, 123] } },
  { "host" : "debugLog", "value" : {"+": [1, 2, 3] } },
  { "host" : "debugLog","value" : {"+": [1,  {"*": [2, 3] } ] } },
 ```
 
-###### String Operations Example
+#### String Operations Example
 ```json
  { "host" : "debugLog", "value" : {"+": ["string", 123] } },
- { "host" : "debugLog",
-   "value" : {"replace": ["This is a badass.", "badass", "awesome"]}},
+ { "host" : "debugLog", "value" : {"replace": ["This is a badass.", "badass", "awesome"]}},
 ```
 
-###### Comparison Operations Example
+#### Comparison Operations Example
 ```json
  { "host" : "debugLog", "value" : {"&&": [true, false] } },
  { "host" : "debugLog", "value" : {"||": [true, false] } },
  { "host" : "debugLog", "value" : {"!": true } },
 ```
 
-###### Misc Operations Example
+#### Misc Operations Example
 ```json
  { "host" : "debugLog", "value" : {"random": 10 } },
 ```
 
-###### Operation Expression format:
+#### Operation Expression format:
 ```json
 {"<operation>": <values>}
 ```
@@ -279,7 +285,7 @@ Where we have:
 operation | One of the operator strings from the Operator table below.
 values | An array of simple values or expressions, or a single value object as input it the operation takes a single parameter.
 
-###### Operation
+##### Operation
 Operator | Description | Number of input | Input type | Example | Means
 -------  | ----------- | --------------- | ---------- | ------- | -----
 \+ | Addition | >=2 | Number | `{"+": [123, 123] }` | 123 + 123
@@ -295,7 +301,7 @@ Operator | Description | Number of input | Input type | Example | Means
 \>= | Greater than or equal to | 2 | Number | `{">=": [123, 2] }` | 123 >= 2
 <= | Less than or equal to | 2 | Number | `{"<=": [123, 2] }` | 123 <= 2
 && | And | 2 | Boolean | `{"&&": [true, false] }` | true && false --> (false)
-\|\| | Or | 2 | Boolean | `{"\|\|": [true, false] }` | true \|\| false --> (true)
+&vert;&vert; | Or | 2 | Boolean | {"&vert;&vert;": [true, false] } | true &vert;&vert; false --> (true)
 ! | Not | 1 | Boolean | `{"!": true }` | !true --> (false)
 replace | String replace | 3 | String | `{"replace": ["Original String to Replace", "Replace", "Modify"] }` | "Original String to Replace".replace("Replace", "Modify")
 random | Random number | 1 | Number | `{"random": 10 }` | random(10)

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -1,20 +1,18 @@
 # BlueScript Documentation
-_rev. 2020-06-08_
+_rev. 2021-09-10
 
 ## Table of Contents
 1. [Overview](#overview)
 1. [Structure](#overall-structure)
-   1. [Top Level Syntax](#top-level-payload-syntax)
+   1. [Top Level Syntax](#top-level-syntax)
    1. [Element Syntax](#bluescript-element-syntax)
    1. [Values and Expressions](#values-and-expressions)
    1. [Examples](#examples)
-1. [Element Reference](#bluescript-element-reference)
+1. [BlueScript Element Reference](#bluescript-element-reference)
    1. [Step](#step)
       1. [Elements](#elements)
       1. [Behaviors](#behaviors)
-         1. [Behavior Events](#behavior-events)
-         1. [Behavior Actions](#behavior-actions)
-      1. [Functions](#functions)
+      1. [Functions](#functions)x
    1. [Rectangle](#rectangle)
    1. [Image](#image)
    1. [Video](#video)
@@ -23,6 +21,9 @@ _rev. 2020-06-08_
    1. [Text](#text)
    1. [Audio](#audio)
    1. [QRCode](#qrcode)
+1. [BlueScript Behavior Reference](#bluescript-behavior-reference)
+   1. [Behavior Events](#behavior-events)
+   1. [Behavior Actions](#behavior-actions)
 1. [Authoring Considerations](#authoring-considerations)
    1. [Memory Management](#memory-management)
 
@@ -44,7 +45,7 @@ BlueScript elements support event handlers, enabling dynamic behavior. These can
 
 ## Overall Structure
 
-### Top Level Payload Syntax
+### Top Level Syntax
 > _**Formatting note**: strings inside of carets (`"< ... >"`) are meta-descriptions, not absolute values_
 
 **Schema:**
@@ -176,8 +177,9 @@ now recommended, as shown below.
 ```
 
 ###### Operation Expression format:
-
+```json
 {"<operation>": <values>}
+```
 
 Where we have:
 operation | One of the operator strings from the Operator table below.
@@ -289,12 +291,12 @@ For each event, an array of behavior **actions** can be defined. BlueScript elem
 
 Property | Default | Description
 --- | --- | ---
-behavior | [ ] | Defines the list of behavior actions to be triggered on specific events. List of event names to triggered behavior action lists.
+behavior | {} | Defines the list of [behavior actions](#behavior-actions) to be triggered on specific [named events](#behavior-events).
 
 <details>
 <summary>For example:</summary>
 
-```
+```json
 {
   "behaviors": {
     "fooLabel": {
@@ -304,9 +306,441 @@ behavior | [ ] | Defines the list of behavior actions to be triggered on specifi
   }
 }
 ```
+
 </details>
 
-#### Behavior Events
+---
+
+#### Functions
+
+TBD
+
+---
+
+### Rectangle
+
+Renders a single-colored rectangle at the specified screen coordinates.
+
+TXRectangle is a simple sub-class of Brightscript's [Rectangle](https://developer.roku.com/docs/references/scenegraph/renderable-nodes/rectangle.md) component that allows us to assign behaviors and play animations. All of the original Rectangle functionality is supported.
+
+#### Example
+
+```json
+{
+   "type": "Rectangle",
+   "name": "sampleOverlay",
+   "x": "0",
+   "y": "0",
+   "width": "1920",
+   "height": "1080",
+   "color": "0x00000080"
+}
+```
+
+#### Rectangle Properties
+
+Property | Default | Description
+--- | --- | ---
+x | 0 | Screen-space X position, where x=0 is the left side of the (assumed 1080p) screen
+y | 0 | Screen-space Y position, where y=0 is the top of the (assumed 1080p) screen
+width | 0 | Specifies the width of the Rectangle on the screen
+height | 0 | Specifies the height of the Rectangle on the screen
+color | 0xFFFFFFFF | Specifies the RGBA color drawn to the rectangle region
+blendingEnabled | true | Specifies if the rectangle should be alpha blended with the nodes that are behind it
+
+#### Rectangle Behavior Events
+
+N/A
+
+#### Rectangle Behavior Actions
+
+N/A
+
+---
+
+### Image
+
+Renders an image at the specified screen coordinates.
+
+#### Example
+
+```json
+{
+   "type": "Image",
+   "name": "hiltonBackgroundImage",
+   "x": "0",
+   "y": "0",
+   "width": "1920",
+   "height": "1080",
+   "image_url": "https://media.truex.com/image_assets/2018-05-22/504a601c-60ef-449c-8281-6d973310d053.jpg"
+}
+```
+
+#### Image Properties
+
+Property | Default | Description
+--- | --- | ---
+x | 0 | X coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
+y | 0 | Y coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
+width | 0 | Specifies the width of the image in local coordinates. If set to 0, the width of the bitmap from the image file is used. If set to a value greater than 0, the bitmap is scaled to that width.
+height | 0 | Specifies the height of the image in local coordinates. If set to 0, the height of the bitmap from the image file is used. If set to a value greater than 0, the bitmap is scaled to that height.
+image_url | N/A (Required) | Specifies the URI to the image file.
+opacity | 1 | In the range [0, 1] where 0 is full transparent and 1 is fully opaque
+forceHighResolution | false | Use the image's native / high resolution on memory constrained low end Roku devices. See below [Memory Management](#memory-management) note.
+
+#### Image Behavior Events
+
+N/A
+
+#### Image Behavior Actions
+
+N/A
+
+---
+
+### Video
+
+Renders a video at the specified screen coordinates.
+
+#### Example
+
+```json
+{
+   "type"      : "Video",
+   "name"      : "videoPlayer",
+   "x"         : "125",
+   "y"         : "175",
+   "width"     : "1138",
+   "height"    : "640",
+   "video_url"       : "https://media.truex.com/video_assets/2018-05-09/e0baa5cc-641f-4773-9ade-156a53f9608c_large.mp4",
+   "loop"      : false,
+   "autoplay"  : false,
+   "trackingName" : "hilton_worktrip_video"
+}
+```
+
+#### Video Properties
+
+Property | Default | Description
+--- | --- | ---
+x | 0 | X coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
+y | 0 | Y coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
+width | 0 | Specifies the width of the video in local coordinates. If set to 0, the video play window is set to the width of the entire display screen.
+height | 0 | Specifies the height of the video in local coordinates. If set to 0, he video play window is set to the height of the entire display screen.
+video_url | N/A (Required) | Specifies the URI to the video file. MP4 format is expected.
+loop | true | If set to true, the video will be restarted from the beginning after the end is reached.
+autoplay | true | If set to true, the video will be automatically started on card display.
+replayable | false | If set to true, makes the video player focusable on playback completion, enabling replay of the video.
+mute | false | Set to true to mute the audio of the video currently playing. Set to false to restore audio.
+fullscreen | false | When toggled, the video will be animated to fullscreen, or back to window
+zoomAnimationDuration | 0.35 | The time it takes to animated between window and fullscreen. The 0.35 is copie from tvOS TAR. (Note: must be > 0)
+easeFunction | "inOutCubic" | This string defines the animation curve. For full list of easeFunction, see: https://sdkdocs.roku.com/display/sdkdoc/Animation#Animation-Fields
+currentTime | N/A | This value is the floating point time of the current stream.  This has a margin of error of 500ms due to how position is handled.
+trackingName | | When set, tracking calls utilize this name instead of the uri to identify videos. Greatly facilitates analysis. Note that when `useRotation` set to true, a `_n` suffix will be added to the trackingName, where `n` is the index of the video with "1 indexing".
+preview_image_url | | When set, implements a static image to overlay on top of the video player on video playback completion.
+focusable | false | Set to true in order to make the video focusable.
+leftFocus | invalid | ID of element to focus when left directional button is pressed.
+rightFocus | invalid | ID of element to focus when right directional button is pressed.
+upFocus | invalid | ID of element to focus when up directional button is pressed.
+downFocus | invalid | ID of element to focus when down directional button is pressed.
+autoFocus | false | If set to true, the video (if focusable) will be focused by default.
+useRotation | false | If set to true, will ignore the video url and try to apply the value of `video_n` from the ad parameters.
+
+#### Notes
+
+On Roku, only a single Media node may be actively playing or buffering media at a given time. This means that it is not possible to have multiple inline videos playing concurrently or a background / ambient video with inline window windows on top. This also precludes the use of background audio playing together with a video.
+
+#### Video Behavior Events
+
+Behavior Event | Description
+--- | ---
+videoStarted | Triggered when the active video has started playback.
+videoCompleted | Triggered when the active video has completed playback.
+videoFirstQuartile | Triggered when the active video has completed 25% of its playback.
+videoSecondQuartile | Triggered when the active video has completed 50% of its playback.
+videoThirdQuartile | Triggered when the active video has completed 75% of its playback.
+videoLooped | Triggered when the active video has looped playback.
+videoDidEnterFullscreen | Triggered when video animated into fullscreen
+videoDidExitFullscreen | Triggered when video animated back to window
+
+#### Video Behavior Actions
+
+##### (1) - `playVideo`
+
+Starts or resumes playback (for a paused video) for the target video.
+
+###### Parameters
+
+Parameter | Description
+--- | ---
+target | Name of the video to play.
+
+##### (2) - `pauseVideo`
+
+Pauses playback for the target video.
+
+###### Parameters
+
+Parameter | Description
+--- | ---
+target | Name of the video to pause.
+
+##### (3) - `resetVideo`
+
+Resets playback for the target video by setting the play head to the beginning.
+
+###### Parameters
+
+Parameter | Description
+--- | ---
+target | Name of the video to reset.
+
+##### (4) - `stopVideo`
+
+Stops playback for the target video.
+
+###### Parameters
+
+Parameter | Description
+--- | ---
+target | Name of the video to stop.
+
+---
+
+### Label
+
+Renders a text label at the specified screen coordinates.
+
+#### Example
+
+```json
+{
+   "type"      : "Text",
+   "name"      : "firstLabel",
+   "x"         : "200",
+   "y"         : "150",
+   "width"     : "800",
+   "height"    : "0",
+   "text"      : "This is the TXAudio Tester"
+}
+```
+
+#### Label Properties
+
+Property | Default | Description
+--- | --- | ---
+x | 0 | X coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
+y | 0 | Y coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
+width | 0 | Specifies the width of the label in local coordinates. If the width field is greater than zero, the computed width is the value of the width field. If the width field is equal to zero, the computed width is the rendered width of the text.
+height | 0 | Specifies the height of the label in local coordinates. If set to 0, the height of the label is computed based on the height of the number of lines of text that need to be rendered. That is, one line of text, unless wrapping is turned on.
+text |  | Specifies the text string to render in the label.
+color | 0xddddddff | Specifies the color of text rendered in the label.  Supports HTML code formats.  RGB formats such as rgb(r,g,b) rgba(r,g,b,a) rgba(r%,g%,b%,a%) with commas or whitespace.  And Hex formats such as  #RGB #RGBA #RRGGBB #RRGGBBAA.
+backgroundColor | 0x00000000 | Specifies the background color for the label, covers the final calculated width and height of the element.  Supports HTML code formats (see color above)
+fontName | (system default) | Specifies the font name for the text rendered in the label. That is either a [built-in](https://sdkdocs.roku.com/display/sdkdoc/Typography) system font, or a TTF/OTF font we ship with the library.
+font_size | 24 | Size of the font, in points. Note that this is only supported for OTF/TTF files, as the default system fonts imply a given font size.
+font_url |   | Fully qualified URL of an OTF/TTF font asset to be dynamically loaded.  Externally hosted unlike fontName and must end with extension .otf/.ttf.
+alignment | center | Horizontal alignment, one of `left`, `center` or `right`.
+vertical_alignment | top | Vertical alignment, one of `top`, `center` or `bottom`.
+wrap | true | The wrap field is used to control how the text is broken into multiple lines. If false, a single line of text will be displayed. Else, the text is broken over multiple lines each of the calculated width, up to the specified height.
+
+#### Label Behavior Events
+
+N/A
+
+#### Label Behavior Actions
+
+N/A. Note: manipulating properties of the label such as `text` `color` and `backgroundColor` can be achieved using the `setAttribute` behavior action.
+
+
+###### Notes
+
+On Roku, the Label element is a thin wrapper on top of a `<Label/>` SceneGraph node. Refer to the [Roku documentation](https://sdkdocs.roku.com/display/sdkdoc/Label) for detailed description of layout and wrapping behavior.
+
+---
+
+### Button
+
+Renders a focusable button at the specified screen coordinates.
+
+#### Example
+
+```json
+{
+   "type"     : "Button",
+   "name"     : "pauseButton",
+   "x"        : "1389",
+   "y"        : "491",
+   "width"    : "403",
+   "height"   : "120",
+   "image_url": "http://development.scratch.truex.com.s3.amazonaws.com/roku/simon/video_tester/pause_button_unsel.png",
+   "behavior" : {
+      "onselect": [
+         { "host" : "flagActivityForAttention" },
+         { "host" : "pauseActiveVideo" }
+      ]
+   }
+}
+```
+
+#### Button Properties
+
+Property | Default | Description
+--- | --- | ---
+x | 0 | X coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
+y | 0 | Y coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
+width | 0 | Specifies the width of the button in local coordinates. If set to 0, the width of the bitmap from the image file is used. If set to a value greater than 0, the bitmap is scaled to that width.
+height | 0 | Specifies the height of the button in local coordinates. If set to 0, the height of the bitmap from the image file is used. If set to a value greater than 0, the bitmap is scaled to that width.
+image_url | N/A (Required) | Specifies the URI to the image file used for the button.
+hover_image_url |  | Specifies the URI to the image file used for the button's focused state.
+checked_image_url |  | Specifies the URI to the image file used for the button's enabled or checked state.
+hover_checked_image_url |  | Specifies the URI to the image file used for the button's focused state when it is used as a toggle style button.
+checked | false | Whether this toggle style button is set to "on" by default.
+hover_effect | true | If set to true, upon focus button grows by a factor of 25%, with no change in the image to the hover_image_url.
+hover_scale | 1.1 | A float value that indicates the how big, in percentage, this button should glow on hover.
+focusable | true | Set to false in order to make the button not focusable.
+forceHighResolution | false | Use the button's native / high resolution on memory constrained low end Roku devices. See below [Memory Management](#memory-management) note.
+leftFocus | invalid | ID of element to focus when left directional button is pressed.
+rightFocus | invalid | ID of element to focus when right directional button is pressed.
+upFocus | invalid | ID of element to focus when up directional button is pressed.
+downFocus | invalid | ID of element to focus when down directional button is pressed.
+autoFocus | false | If set to true, the button will be focused by default.
+
+#### Button Behavior Events
+
+Behavior Event | Description
+--- | ---
+onFocusGained | Triggered when the button receives focus.
+onFocusLost | Triggered when the button loses focus.
+onSelect | Triggered when the button is selected.
+
+#### Button Behavior Actions
+
+N/A. Note: manipulating properties of the button such as `checked` can be achieved using the `setAttribute` behavior action.
+
+---
+
+### Text
+
+TBD
+
+---
+
+### Audio
+
+Plays background audio.
+
+#### Example
+
+```json
+{
+   "type"      : "Audio",
+   "name"      : "backgroundAudio",
+   "audio_url"       : "http://development.scratch.truex.com.s3.amazonaws.com/roku/simon/audio_tester/audio_test.mp3",
+   "autoplay"  : false,
+   "loop"      : true
+}
+```
+
+#### Audio Properties
+
+Property | Default | Description
+--- | --- | ---
+audio_url | N/A (Required) | Specifies the URI to the audio file. MP3 format* is expected. Always use the Asset Uploader.
+loop | true | If set to true, the audio will restart from the beginning after the end is reached.
+autoplay | true | If set to true, the audio will be automatically started on card display.
+global | false | If true, audio sticks/continues playing across card transitions.
+
+#### Notes
+
+On Roku, only a single Media node may be actively playing or buffering media at a given time. This means that it is not possible to have multiple inline videos playing concurrently or a background / ambient video with inline window windows on top. This also precludes the use of background audio playing together with a video. Any additional stream started after the first one will fail silently.
+
+Note on MP3 format. On PlayStation, and some other platforms, MP3 is not supported. BlueScript engine will try to get the MP4 version (same location, same name) of the given audio instead. Asset Uploader in True Exchange is encoding that MP4 file automatically. Be sure to include a MP4 version of your audio file if you cannot use the Asset Uploader.
+
+#### Audio Behavior Events
+
+N/A
+
+#### Audio Behavior Actions
+
+##### (1) - `playActiveAudio`
+
+Starts or resumes playback (for a paused file) for the active audio element.
+
+###### Parameters
+
+N/A
+
+##### (2) - `pauseActiveAudio`
+
+Pauses playback for the active audio element.
+
+###### Parameters
+
+N/A
+
+##### (3) - `resetActiveAudio`
+
+Resets playback for the active audio element by setting the play head to the beginning.
+
+###### Parameters
+
+N/A
+
+##### (4) - `stopActiveAudio`
+
+Stops playback for the active audio element.
+
+###### Parameters
+
+N/A
+
+---
+
+### QRCode
+
+Renders a QR Code as image using the [qr-code-generator](https://github.com/socialvibe/ui_misc/tree/master/lambda_functions/qr-code-generator).
+
+#### Example
+
+```json
+{
+   "type"     : "QRCode",
+   "name"     : "qr_code",
+   "x"        : "824",
+   "y"        : "312",
+   "width"    : "264",
+   "height"   : "264",
+   "size"     : "250",
+   "margin"   : "4",
+   "url"      : "https://www.engagementshowcase.com/#sponsored-ad-break-ctv/ca1f7fa6d/",
+   "color"    : "000000",
+   "backgroundColor" : "ffffff",
+   "minify"   : "true",
+   "tagLabel" : "main_qr"
+}
+```
+
+#### Button Properties
+
+Property | Default | Description
+--- | --- | ---
+x | 0 | X coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
+y | 0 | Y coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
+width | 0 | Specifies the width of the button in local coordinates. If set to 0, the width of the bitmap from the image file is used. If set to a value greater than 0, the bitmap is scaled to that width.
+height | 0 | Specifies the height of the button in local coordinates. If set to 0, the height of the bitmap from the image file is used. If set to a value greater than 0, the bitmap is scaled to that width.
+url | | Specifies the information that is encoded in the QR Code image. This is also the fallback url for the tagLabel option. Using this field without setting the tagLabel will generate a QR Code contains only the information in this field, with no 1st party tracking. One should give the tagLabel a value (that does not have "Click" tag set) to get the trackings.
+size | dynamic | Specifies the native size in pixels of the QR Code image being returned.
+margin | 4 | Specifies the margin, in number of dots in QR Code matrix.
+color | 0xddddddff | Specifies the color of dots rendered in the QR Code.
+backgroundColor | 0x00000000 | Specifies the background color for the QR Code, covers the final calculated width and height of the element.
+minify | false | Specifies if we would pass final url to `multidevice.truex.com/minify` for minimize.
+tagLabel | (empty) | Specifies if this QR Code should take its url from the tag manager with the matching label. When set, the `url` field is ignored, and TAR will try to get the last matching label from the Tag Mangager, with Trigger "QR Code" (`qr_code`), and Type "Click"; all the other 3rd party pixels with Trigger "QR Code" (`qr_code`), and Type "Pixel"; as well as a 1st party pixel. We will use the `interact.live` redirect service to redirect, and fires all the necessary pixel. If there is no matching "Click" with this given the tagLabel, TAR will use the url field as the fallback redirect url.
+
+---
+
+## BlueScript Behavior Reference
+
+### Behavior Events
 
 The following are the top-level events that behaviors can be triggered from:
 
@@ -325,9 +759,10 @@ videoThirdQuartile | Triggered when 75% of the video has played.
 videoCompleted | Triggered when the video has completed playback.
 videoLooped | Triggered when the video has automatically restarted playback.
 
-#### Behavior Actions
+### Behavior Actions
 
-This section details the **Behavior Actions** that are available to any BlueScript element. Actions are invoked when Events occur.
+This section details the **Behavior Actions** that are available to any BlueScript element. 
+Actions are invoked when Events occur, or when a BlueScript function is invoked.
 
 ##### (1) - `allDoneButtonPushed`
 
@@ -759,432 +1194,6 @@ height |  | new height of element
 
 All new values are optional by excluding them in the action.  For example, if you only want to change x,y and leave width,height alone.
 
----
-
-#### Functions
-
-TBD
-
----
-
-### Rectangle
-
-Renders a single-colored rectangle at the specified screen coordinates.
-
-TXRectangle is a simple sub-class of Brightscript's [Rectangle](https://developer.roku.com/docs/references/scenegraph/renderable-nodes/rectangle.md) component that allows us to assign behaviors and play animations. All of the original Rectangle functionality is supported.
-
-#### Example
-
-```json
-{
-   "type": "Rectangle",
-   "name": "sampleOverlay",
-   "x": "0",
-   "y": "0",
-   "width": "1920",
-   "height": "1080",
-   "color": "0x00000080"
-}
-```
-
-#### Rectangle Properties
-
-Property | Default | Description
---- | --- | ---
-x | 0 | Screen-space X position, where x=0 is the left side of the (assumed 1080p) screen
-y | 0 | Screen-space Y position, where y=0 is the top of the (assumed 1080p) screen
-width | 0 | Specifies the width of the Rectangle on the screen
-height | 0 | Specifies the height of the Rectangle on the screen
-color | 0xFFFFFFFF | Specifies the RGBA color drawn to the rectangle region
-blendingEnabled | true | Specifies if the rectangle should be alpha blended with the nodes that are behind it
-
-#### Rectangle Behavior Events
-
-N/A
-
-#### Rectangle Behavior Actions
-
-N/A
-
----
-
-### Image
-
-Renders an image at the specified screen coordinates.
-
-#### Example
-
-```json
-{
-   "type": "Image",
-   "name": "hiltonBackgroundImage",
-   "x": "0",
-   "y": "0",
-   "width": "1920",
-   "height": "1080",
-   "image_url": "https://media.truex.com/image_assets/2018-05-22/504a601c-60ef-449c-8281-6d973310d053.jpg"
-}
-```
-
-#### Image Properties
-
-Property | Default | Description
---- | --- | ---
-x | 0 | X coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
-y | 0 | Y coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
-width | 0 | Specifies the width of the image in local coordinates. If set to 0, the width of the bitmap from the image file is used. If set to a value greater than 0, the bitmap is scaled to that width.
-height | 0 | Specifies the height of the image in local coordinates. If set to 0, the height of the bitmap from the image file is used. If set to a value greater than 0, the bitmap is scaled to that height.
-image_url | N/A (Required) | Specifies the URI to the image file.
-opacity | 1 | In the range [0, 1] where 0 is full transparent and 1 is fully opaque
-forceHighResolution | false | Use the image's native / high resolution on memory constrained low end Roku devices. See below [Memory Management](#memory-management) note.
-
-#### Image Behavior Events
-
-N/A
-
-#### Image Behavior Actions
-
-N/A
-
----
-
-### Video
-
-Renders a video at the specified screen coordinates.
-
-#### Example
-
-```json
-{
-   "type"      : "Video",
-   "name"      : "videoPlayer",
-   "x"         : "125",
-   "y"         : "175",
-   "width"     : "1138",
-   "height"    : "640",
-   "video_url"       : "https://media.truex.com/video_assets/2018-05-09/e0baa5cc-641f-4773-9ade-156a53f9608c_large.mp4",
-   "loop"      : false,
-   "autoplay"  : false,
-   "trackingName" : "hilton_worktrip_video"
-}
-```
-
-#### Video Properties
-
-Property | Default | Description
---- | --- | ---
-x | 0 | X coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
-y | 0 | Y coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
-width | 0 | Specifies the width of the video in local coordinates. If set to 0, the video play window is set to the width of the entire display screen.
-height | 0 | Specifies the height of the video in local coordinates. If set to 0, he video play window is set to the height of the entire display screen.
-video_url | N/A (Required) | Specifies the URI to the video file. MP4 format is expected.
-loop | true | If set to true, the video will be restarted from the beginning after the end is reached.
-autoplay | true | If set to true, the video will be automatically started on card display.
-replayable | false | If set to true, makes the video player focusable on playback completion, enabling replay of the video.
-mute | false | Set to true to mute the audio of the video currently playing. Set to false to restore audio.
-fullscreen | false | When toggled, the video will be animated to fullscreen, or back to window
-zoomAnimationDuration | 0.35 | The time it takes to animated between window and fullscreen. The 0.35 is copie from tvOS TAR. (Note: must be > 0)
-easeFunction | "inOutCubic" | This string defines the animation curve. For full list of easeFunction, see: https://sdkdocs.roku.com/display/sdkdoc/Animation#Animation-Fields
-currentTime | N/A | This value is the floating point time of the current stream.  This has a margin of error of 500ms due to how position is handled.
-trackingName | | When set, tracking calls utilize this name instead of the uri to identify videos. Greatly facilitates analysis. Note that when `useRotation` set to true, a `_n` suffix will be added to the trackingName, where `n` is the index of the video with "1 indexing".
-preview_image_url | | When set, implements a static image to overlay on top of the video player on video playback completion.
-focusable | false | Set to true in order to make the video focusable.
-leftFocus | invalid | ID of element to focus when left directional button is pressed.
-rightFocus | invalid | ID of element to focus when right directional button is pressed.
-upFocus | invalid | ID of element to focus when up directional button is pressed.
-downFocus | invalid | ID of element to focus when down directional button is pressed.
-autoFocus | false | If set to true, the video (if focusable) will be focused by default.
-useRotation | false | If set to true, will ignore the video url and try to apply the value of `video_n` from the ad parameters.
-
-#### Notes
-
-On Roku, only a single Media node may be actively playing or buffering media at a given time. This means that it is not possible to have multiple inline videos playing concurrently or a background / ambient video with inline window windows on top. This also precludes the use of background audio playing together with a video.
-
-#### Video Behavior Events
-
-Behavior Event | Description
---- | ---
-videoStarted | Triggered when the active video has started playback.
-videoCompleted | Triggered when the active video has completed playback.
-videoFirstQuartile | Triggered when the active video has completed 25% of its playback.
-videoSecondQuartile | Triggered when the active video has completed 50% of its playback.
-videoThirdQuartile | Triggered when the active video has completed 75% of its playback.
-videoLooped | Triggered when the active video has looped playback.
-videoDidEnterFullscreen | Triggered when video animated into fullscreen
-videoDidExitFullscreen | Triggered when video animated back to window
-
-#### Video Behavior Actions
-
-##### (1) - `playVideo`
-
-Starts or resumes playback (for a paused video) for the target video.
-
-###### Parameters
-
-Parameter | Description
---- | ---
-target | Name of the video to play.
-
-##### (2) - `pauseVideo`
-
-Pauses playback for the target video.
-
-###### Parameters
-
-Parameter | Description
---- | ---
-target | Name of the video to pause.
-
-##### (3) - `resetVideo`
-
-Resets playback for the target video by setting the play head to the beginning.
-
-###### Parameters
-
-Parameter | Description
---- | ---
-target | Name of the video to reset.
-
-##### (4) - `stopVideo`
-
-Stops playback for the target video.
-
-###### Parameters
-
-Parameter | Description
---- | ---
-target | Name of the video to stop.
-
----
-
-### Label
-
-Renders a text label at the specified screen coordinates.
-
-#### Example
-
-```json
-{
-   "type"      : "Text",
-   "name"      : "firstLabel",
-   "x"         : "200",
-   "y"         : "150",
-   "width"     : "800",
-   "height"    : "0",
-   "text"      : "This is the TXAudio Tester"
-}
-```
-
-#### Label Properties
-
-Property | Default | Description
---- | --- | ---
-x | 0 | X coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
-y | 0 | Y coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
-width | 0 | Specifies the width of the label in local coordinates. If the width field is greater than zero, the computed width is the value of the width field. If the width field is equal to zero, the computed width is the rendered width of the text.
-height | 0 | Specifies the height of the label in local coordinates. If set to 0, the height of the label is computed based on the height of the number of lines of text that need to be rendered. That is, one line of text, unless wrapping is turned on.
-text |  | Specifies the text string to render in the label.
-color | 0xddddddff | Specifies the color of text rendered in the label.  Supports HTML code formats.  RGB formats such as rgb(r,g,b) rgba(r,g,b,a) rgba(r%,g%,b%,a%) with commas or whitespace.  And Hex formats such as  #RGB #RGBA #RRGGBB #RRGGBBAA.
-backgroundColor | 0x00000000 | Specifies the background color for the label, covers the final calculated width and height of the element.  Supports HTML code formats (see color above)
-fontName | (system default) | Specifies the font name for the text rendered in the label. That is either a [built-in](https://sdkdocs.roku.com/display/sdkdoc/Typography) system font, or a TTF/OTF font we ship with the library.
-font_size | 24 | Size of the font, in points. Note that this is only supported for OTF/TTF files, as the default system fonts imply a given font size.
-font_url |   | Fully qualified URL of an OTF/TTF font asset to be dynamically loaded.  Externally hosted unlike fontName and must end with extension .otf/.ttf.
-alignment | center | Horizontal alignment, one of `left`, `center` or `right`.
-vertical_alignment | top | Vertical alignment, one of `top`, `center` or `bottom`.
-wrap | true | The wrap field is used to control how the text is broken into multiple lines. If false, a single line of text will be displayed. Else, the text is broken over multiple lines each of the calculated width, up to the specified height.
-
-#### Label Behavior Events
-
-N/A
-
-#### Label Behavior Actions
-
-N/A. Note: manipulating properties of the label such as `text` `color` and `backgroundColor` can be achieved using the `setAttribute` behavior action.
-
-
-###### Notes
-
-On Roku, the Label element is a thin wrapper on top of a `<Label/>` SceneGraph node. Refer to the [Roku documentation](https://sdkdocs.roku.com/display/sdkdoc/Label) for detailed description of layout and wrapping behavior.
-
----
-
-### Button
-
-Renders a focusable button at the specified screen coordinates.
-
-#### Example
-
-```json
-{
-   "type"     : "Button",
-   "name"     : "pauseButton",
-   "x"        : "1389",
-   "y"        : "491",
-   "width"    : "403",
-   "height"   : "120",
-   "image_url": "http://development.scratch.truex.com.s3.amazonaws.com/roku/simon/video_tester/pause_button_unsel.png",
-   "behavior" : {
-      "onselect": [
-         { "host" : "flagActivityForAttention" },
-         { "host" : "pauseActiveVideo" }
-      ]
-   }
-}
-```
-
-#### Button Properties
-
-Property | Default | Description
---- | --- | ---
-x | 0 | X coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
-y | 0 | Y coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
-width | 0 | Specifies the width of the button in local coordinates. If set to 0, the width of the bitmap from the image file is used. If set to a value greater than 0, the bitmap is scaled to that width.
-height | 0 | Specifies the height of the button in local coordinates. If set to 0, the height of the bitmap from the image file is used. If set to a value greater than 0, the bitmap is scaled to that width.
-image_url | N/A (Required) | Specifies the URI to the image file used for the button.
-hover_image_url |  | Specifies the URI to the image file used for the button's focused state.
-checked_image_url |  | Specifies the URI to the image file used for the button's enabled or checked state.
-hover_checked_image_url |  | Specifies the URI to the image file used for the button's focused state when it is used as a toggle style button.
-checked | false | Whether this toggle style button is set to "on" by default.
-hover_effect | true | If set to true, upon focus button grows by a factor of 25%, with no change in the image to the hover_image_url.
-hover_scale | 1.1 | A float value that indicates the how big, in percentage, this button should glow on hover.
-focusable | true | Set to false in order to make the button not focusable.
-forceHighResolution | false | Use the button's native / high resolution on memory constrained low end Roku devices. See below [Memory Management](#memory-management) note.
-leftFocus | invalid | ID of element to focus when left directional button is pressed.
-rightFocus | invalid | ID of element to focus when right directional button is pressed.
-upFocus | invalid | ID of element to focus when up directional button is pressed.
-downFocus | invalid | ID of element to focus when down directional button is pressed.
-autoFocus | false | If set to true, the button will be focused by default.
-
-#### Button Behavior Events
-
-Behavior Event | Description
---- | ---
-onFocusGained | Triggered when the button receives focus.
-onFocusLost | Triggered when the button loses focus.
-onSelect | Triggered when the button is selected.
-
-#### Button Behavior Actions
-
-N/A. Note: manipulating properties of the button such as `checked` can be achieved using the `setAttribute` behavior action.
-
----
-
-### Text
-
-TBD
-
----
-
-### Audio
-
-Plays background audio.
-
-#### Example
-
-```json
-{
-   "type"      : "Audio",
-   "name"      : "backgroundAudio",
-   "audio_url"       : "http://development.scratch.truex.com.s3.amazonaws.com/roku/simon/audio_tester/audio_test.mp3",
-   "autoplay"  : false,
-   "loop"      : true
-}
-```
-
-#### Audio Properties
-
-Property | Default | Description
---- | --- | ---
-audio_url | N/A (Required) | Specifies the URI to the audio file. MP3 format* is expected. Always use the Asset Uploader.
-loop | true | If set to true, the audio will restart from the beginning after the end is reached.
-autoplay | true | If set to true, the audio will be automatically started on card display.
-global | false | If true, audio sticks/continues playing across card transitions.
-
-#### Notes
-
-On Roku, only a single Media node may be actively playing or buffering media at a given time. This means that it is not possible to have multiple inline videos playing concurrently or a background / ambient video with inline window windows on top. This also precludes the use of background audio playing together with a video. Any additional stream started after the first one will fail silently.
-
-Note on MP3 format. On PlayStation, and some other platforms, MP3 is not supported. BlueScript engine will try to get the MP4 version (same location, same name) of the given audio instead. Asset Uploader in True Exchange is encoding that MP4 file automatically. Be sure to include a MP4 version of your audio file if you cannot use the Asset Uploader.
-
-#### Audio Behavior Events
-
-N/A
-
-#### Audio Behavior Actions
-
-##### (1) - `playActiveAudio`
-
-Starts or resumes playback (for a paused file) for the active audio element.
-
-###### Parameters
-
-N/A
-
-##### (2) - `pauseActiveAudio`
-
-Pauses playback for the active audio element.
-
-###### Parameters
-
-N/A
-
-##### (3) - `resetActiveAudio`
-
-Resets playback for the active audio element by setting the play head to the beginning.
-
-###### Parameters
-
-N/A
-
-##### (4) - `stopActiveAudio`
-
-Stops playback for the active audio element.
-
-###### Parameters
-
-N/A
-
----
-
-### QRCode
-
-Renders a QR Code as image using the [qr-code-generator](https://github.com/socialvibe/ui_misc/tree/master/lambda_functions/qr-code-generator).
-
-#### Example
-
-```json
-{
-   "type"     : "QRCode",
-   "name"     : "qr_code",
-   "x"        : "824",
-   "y"        : "312",
-   "width"    : "264",
-   "height"   : "264",
-   "size"     : "250",
-   "margin"   : "4",
-   "url"      : "https://www.engagementshowcase.com/#sponsored-ad-break-ctv/ca1f7fa6d/",
-   "color"    : "000000",
-   "backgroundColor" : "ffffff",
-   "minify"   : "true",
-   "tagLabel" : "main_qr"
-}
-```
-
-#### Button Properties
-
-Property | Default | Description
---- | --- | ---
-x | 0 | X coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
-y | 0 | Y coordinate for the component, assumes origin at the top left, and a 1080p sized canvas.
-width | 0 | Specifies the width of the button in local coordinates. If set to 0, the width of the bitmap from the image file is used. If set to a value greater than 0, the bitmap is scaled to that width.
-height | 0 | Specifies the height of the button in local coordinates. If set to 0, the height of the bitmap from the image file is used. If set to a value greater than 0, the bitmap is scaled to that width.
-url | | Specifies the information that is encoded in the QR Code image. This is also the fallback url for the tagLabel option. Using this field without setting the tagLabel will generate a QR Code contains only the information in this field, with no 1st party tracking. One should give the tagLabel a value (that does not have "Click" tag set) to get the trackings.
-size | dynamic | Specifies the native size in pixels of the QR Code image being returned.
-margin | 4 | Specifies the margin, in number of dots in QR Code matrix.
-color | 0xddddddff | Specifies the color of dots rendered in the QR Code.
-backgroundColor | 0x00000000 | Specifies the background color for the QR Code, covers the final calculated width and height of the element.
-minify | false | Specifies if we would pass final url to `multidevice.truex.com/minify` for minimize.
-tagLabel | (empty) | Specifies if this QR Code should take its url from the tag manager with the matching label. When set, the `url` field is ignored, and TAR will try to get the last matching label from the Tag Mangager, with Trigger "QR Code" (`qr_code`), and Type "Click"; all the other 3rd party pixels with Trigger "QR Code" (`qr_code`), and Type "Pixel"; as well as a 1st party pixel. We will use the `interact.live` redirect service to redirect, and fires all the necessary pixel. If there is no matching "Click" with this given the tagLabel, TAR will use the url field as the fallback redirect url.
 
 ---
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -752,6 +752,13 @@ All globals values are maintained across step displays. Local variables are main
 
 ---
 
+##### `break`
+
+Exits the current for loop, execution continues with any hosted actions that might follow the `for` action. 
+
+If not current executing a `for` loop, a script error is thrown.
+
+---
 
 ##### `bringToFront`
 
@@ -1023,6 +1030,14 @@ Resets playback for the target video by setting the play head to the beginning.
 Parameter | Description
 --- | ---
 target | Name of the video to reset.
+
+---
+
+##### `return`
+
+Exits the current event handler or function invocation.
+
+If in a function invocation, execution resumes with the action following the calling invoke action or expression.
 
 ---
 

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -339,9 +339,10 @@ now recommended, as shown with the examples below:
 { "host" : "debugLog", "value" : {"local":  "now.time"} },           // 1631316792480, e.g. millis since Jan 1, 1970
 
 {"host": "assign", "local": "now", "value":  {"date":  1631316792480}}, // from timestamp
+{"host": "assign", "local": "millsPerWeek", "value": {"*": [7, 24, 60, 60, 1000]}},
 {
   "host": "assign", "local": "nextWeek", 
-  "value": {"date": {"+": [{"local": "now.time"}, {"*": [7, 24, 60, 60, 1000]}]}}
+  "value": {"date": {"+": [{"local": "now.time"}, {"local": "millisPerWeek"}]}}
 },
 
 { "host": "assign", "local": "yearStart", "value":  {"date": {"year": 2021}} },

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -403,8 +403,6 @@ i.e. the possible elements of a step's "elements" array.
 
 Renders a single-colored rectangle at the specified screen coordinates.
 
-TXRectangle is a simple sub-class of Brightscript's [Rectangle](https://developer.roku.com/docs/references/scenegraph/renderable-nodes/rectangle.md) component that allows us to assign behaviors and play animations. All of the original Rectangle functionality is supported.
-
 For example:
 ```json
 {

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -1150,6 +1150,8 @@ Parameter | Description
 --- | ---
 target | Name of the video to stop.
 
+---
+
 ##### `trackCustomEvent`
 
 Tracks an event back to the true[X] server. This can be used to report back custom events and activity done by a viewer in the unit, such that it can be used for client-facing reports later on.

--- a/bluescript-reference.md
+++ b/bluescript-reference.md
@@ -720,23 +720,23 @@ NOTES:
 
 ##### `assign`
 
-Behavior Action `assign` is an assignment statement that sets and/or re-sets the value stored in the storage denoted by a variable name (named by key); in other words, it copies a value into the variable.
+Behavior Action `assign` is an assignment statement that sets and/or re-sets the value stored in the storage denoted
+by a global key variable or local variable, as named by using `key` vs `local`; in other words, it sets the variable 
+to have the specified value.
+
+All globals values are maintained across step displays. 
+Local variables are maintained during the current event handler or function invocation.
+
+As discussed in [Stored Values](#stored-values), one can assign to object value fields with the `obj.field` notation,
+including numeric fields that serve as array indices.
 
 For example:
 ```json
- { "host" : "assign",
-   "key" : "i",
-   "value" : 0 },
- { "host" : "assign",
-   "key" : "i",
-   "value" : { "+": [{ "key": "i" }, 1] } },
- { "host" : "assign",
-   "key" : "object.array.0",
-   "value" : "Hello World" },
- { "host" : "assign",
-   "key" : { "+": ["object.array.", { "key": "i" } ] ,
-   "value" : { "key": "i" }},
- }
+{ "host" : "assign", "key" : "i", "value" : 0 },
+{ "host" : "assign", "key" : "i", "value" : { "+": [{ "key": "i" }, 1] } },
+{ "host" : "assign", "local" : "localVar", "value" : "a local value" },
+{ "host" : "assign", "key" : "object.array.0", "value" : "Hello World" },
+{ "host" : "assign", "key" : { "+": ["object.array.", { "key": "i" } ] , "value" : { "key": "i" }}}
 ```
 
 Parameter | Description
@@ -744,8 +744,6 @@ Parameter | Description
 key | Name of global variable. It can be a dot seperated list to indicate variable inside objects, or array. (could be [value or expression](#values-and-expressions))
 local | Name of a local variable. Either `key` or `local` must be specified.
 value | Value of the variable (could be an expression).
-
-All globals values are maintained across step displays. Local variables are maintained during the current event handler or function invocation.
 
 ---
 


### PR DESCRIPTION
bluescript doc update, now includes new actions (break, return), expressions.

Reorganized to be easier to read through and navigate.

I don't think that reviewing the diffs would be useful. I suggest to instead just view the file source as it is meant to be [displayed in git hub](https://github.com/socialvibe/truex-ads-docs/blob/task/CTV-3167-update-bluescript-doc-to-latest-truth/bluescript-reference.md). 