### PR TITLE
PI-2745 Update WSAPI and Reporting API docs

### DIFF
--- a/reporting_api.md
+++ b/reporting_api.md
@@ -1,0 +1,118 @@
+# Reporting API
+
+## Publisher Performance Report (JSON)
+
+### URL:
+```
+http://api.truex.com/v1/publisher/performance.json
+```
+
+### Parameters:
+
+- `api_key` (STRING) - The partner-specific reporting api key provided by true[X]
+- `start_date` (STRING, YYYY-MM-DD) - Begin report on the date specified.
+- `end_date` (STRING, YYYY-MM-DD) - End report on the date specified 
+[Optional, default is today]
+
+
+### HTTP Method(s):
+`GET`
+
+### Response Format:
+`JSON`
+
+### Response:
+A JSON object intended for programmatic consumption. Revenue information and key performance indicators are broken out by placement key, day, and campaign (identified by a CAMPAIGN_ID). 
+
+#### Sample Request/Response:
+```
+http://api.truex.com/v1/publisher/performance.json?api_key=[API_KEY]&start_date=YYYY-MM-DD
+```
+
+```json
+{
+  "PLACEMENT_KEY_ONE" : {
+    "YYYY-MM-DD" : {
+      CAMPAIGN_ID: {
+        "day" : "YYYY-MM-DD",
+        "placement_hash" : "Your Placement Hash",
+        "placement_name" : "Your Placement",
+        "company" : "Your Company",
+        "campaign_id" : 1000,
+        "campaign_name" : "Brand Campaign",
+        "campaign_start_date" : "YYYY-MM-DD",
+        "campaign_end_date" : "YYYY-MM-DD",
+        "daily_frequency_cap" : 12,
+        "lifetime_frequency_cap" : 10,
+        "country_targets" : "US,CA",
+        "state_targets" : "CA,NV",
+        "dma_targets" : "618,623,807,862,866,868",
+        "postal_code_targets" : "90291",
+        "initial_engagements": 42,
+        "completed_engagements": 37,
+        "advertiser_cost" : "100.00",
+        "average_cpe" : "0.12",
+        "net_revenue" : "80.00",
+        "cap_type": "units"
+      },
+      CAMPAIGN_ID: {
+        "day" : "YYYY-MM-DD",
+        "placement_hash" : "Your Placement Hash",
+        "placement_name" : "Your Placement",
+        "company" : "Your Company",
+        "campaign_id" : 1000,
+        "campaign_name" : "Brand Campaign",
+        "campaign_start_date" : "YYYY-MM-DD",
+        "campaign_end_date" : "YYYY-MM-DD",
+        "daily_frequency_cap" : 12,
+        "lifetime_frequency_cap" : 10,
+        "country_targets" : "US,CA",
+        "state_targets" : "CA,NV",
+        "dma_targets" : "618,623,807,862,866,868",
+        "postal_code_targets" : "90291",
+        "initial_engagements": 42,
+        "completed_engagements": 37,
+        "advertiser_cost" : "100.00",
+        "average_cpe" : "0.12",
+        "net_revenue" : "80.00",
+        "cap_type" : ""units"
+      }
+    }
+  }
+}
+```
+
+## Publisher Performance Report (CSV)
+
+### URL:
+```
+http://api.truex.com/v1/publisher/performance.csv
+```
+
+### Parameters:
+
+- `api_key` (STRING) - The partner-specific reporting api key provided by true[X]
+- `start_date` (STRING, YYYY-MM-DD) - Begin report on the date specified.
+- `end_date` (STRING, YYYY-MM-DD) - End report on the date specified 
+[Optional, default is today]
+
+
+### HTTP Method(s):
+`GET`
+
+### Response Format:
+`CSV`
+
+### Response:
+The same data as the JSON report but in CSV format. Useful for importing into a spreadsheet for further manipulation. For programmatic consumption we recommend using the JSON format instead.
+
+
+#### Sample Request/Response:
+```
+http://api.truex.com/v1/publisher/performance.csv?api_key=[API_KEY]&start_date=YYYY-MM-DD
+```
+```csv
+Placement Hash,Day,Campaign Id,Campaign Name,Campaign Start Date,Campaign End Date,Daily Frequency Cap,Lifetime Frequency Cap,Country Targets,State Targets,DMA Targets,Postal Code Targets,Initial Engagements, Completed Engagements,Placement Name,Net Revenue,Advertiser Cost,Company,Average CPE, Cap Type
+PLACEMENT_HASH_ONE,YYYY-MM-DD,1000,CAMPAIGN_NAME,YYYY-MM-DD,YYYY-MM-DD,12,20,US,CA,618,90291,0.30,2,100,PLACEMENT_NAME,80.00,100,COMPANY_NAME,0.25,units
+PLACEMENT_HASH_TWO,YYYY-MM-DD,1000,CAMPAIGN_NAME,YYYY-MM-DD,YYYY-MM-DD,12,20,US,CA,618,90291,42,37,100,PLACEMENT_NAME,80.00,100,COMPANY_NAME,0.25,units
+```

--- a/web_service_ad_api.md
+++ b/web_service_ad_api.md
@@ -37,7 +37,7 @@ https://get.truex.com/v2?placement.key=c0b37fa4bd62dd79046e392aa4f6f005aae4f2e5&
 ```
 
 ## Response
-A `activity` JSON object.  Or `{"error": "No bid found"}` if no ads are available.
+An `ad` JSON object.  Or `{"error": "No bid found"}` if no ads are available.
 #### Format: `JSON`
 | Field | Description |
 | ------------- | ------------- |
@@ -66,9 +66,9 @@ A `activity` JSON object.  Or `{"error": "No bid found"}` if no ads are availabl
 ```
 
 ## Using a WSAPI response with the Javascript Client
-Should you want to get the benefits of client-side callbacks and event handling while checking for available activities using the Web Service API, you can do so.
+Should you want to get the benefits of client-side callbacks and event handling while checking for available ads using the Web Service API, you can do so.
 
-Include the javascript client on your page, and use the `truex.client.prepareActivity` like so:
+Include the javascript client on your page, and use the `truex.client.prepareAd` like so:
 
 ```html
 <div id='tx_container'></div>
@@ -76,32 +76,32 @@ Include the javascript client on your page, and use the `truex.client.prepareAct
 <script type='text/javascript' src='https://static.truex.com/js/client.js'></script>
 
 <script>
-	// activity is JSON returned from WSAPI
-	var openActivityFromWSAPI = function(activity) { 
+	// ad is JSON returned from WSAPI
+	var openAdFromWSAPI = function(ad) { 
 		truex.client(options, function(client) {
 
-			// prepareActivity adds the event handler hooks
-			client.prepareActivity(activity);
+			// prepareAd adds the event handler hooks
+			client.prepareAd(ad);
 
 			// you can now listen for these events
-			activity.onStart(function(activity){
-				alert(activity.id + ' started!')
+			ad.onStart(function(ad){
+				alert(ad.id + ' started!')
 			});
 			
-			activity.onClose(function(activity){
-				alert(activity.id + ' closed!')
+			ad.onClose(function(ad){
+				alert(ad.id + ' closed!')
 			});
 
-			activity.onCredit(function(engagement){
+			ad.onCredit(function(ad){
 				alert(engagement.signature + ' credit!')
 			});
 
-			activity.onFinish(function(activity){
-				alert(activity.id + ' onFinish!')
+			ad.onFinish(function(ad){
+				alert(ad.id + ' onFinish!')
 			});
 
-			// use the loadActivityIntoContainer to load the ad unit in a div on your page
-			client.loadActivityIntoContainer(activity, document.getElementById(‘tx_container’));
+			// use the loadAdIntoContainer to load the ad unit in a div on your page
+			client.loadAdIntoContainer(ad, document.getElementById(‘tx_container’));
 		});
 	};
 </script>

--- a/web_service_ad_api.md
+++ b/web_service_ad_api.md
@@ -37,7 +37,7 @@ https://get.truex.com/v2?placement.key=c0b37fa4bd62dd79046e392aa4f6f005aae4f2e5&
 ```
 
 ## Response
-An `ad` JSON object.  Or `{"error": "No bid found"}` if no ads are available.
+A `activity` JSON object.  Or `{"error": "No bid found"}` if no ads are available.
 #### Format: `JSON`
 | Field | Description |
 | ------------- | ------------- |
@@ -63,4 +63,105 @@ An `ad` JSON object.  Or `{"error": "No bid found"}` if no ads are available.
 	"revenue_amount": "0.1",
 	"session_id": "i_wktnzfS1G6yqdp57lSIw"
 }
+```
+
+## Using a WSAPI response with the Javascript Client
+Should you want to get the benefits of client-side callbacks and event handling while checking for available activities using the Web Service API, you can do so.
+
+Include the javascript client on your page, and use the `truex.client.prepareActivity` like so:
+
+```html
+<div id='tx_container'></div>
+
+<script type='text/javascript' src='https://static.truex.com/js/client.js'></script>
+
+<script>
+	// activity is JSON returned from WSAPI
+	var openActivityFromWSAPI = function(activity) { 
+		truex.client(options, function(client) {
+
+			// prepareActivity adds the event handler hooks
+			client.prepareActivity(activity);
+
+			// you can now listen for these events
+			activity.onStart(function(activity){
+				alert(activity.id + ' started!')
+			});
+			
+			activity.onClose(function(activity){
+				alert(activity.id + ' closed!')
+			});
+
+			activity.onCredit(function(engagement){
+				alert(engagement.signature + ' credit!')
+			});
+
+			activity.onFinish(function(activity){
+				alert(activity.id + ' onFinish!')
+			});
+
+			// use the loadActivityIntoContainer to load the ad unit in a div on your page
+			client.loadActivityIntoContainer(activity, document.getElementById(‘tx_container’));
+		});
+	};
+</script>
+```
+
+## Server-side Callback Specification (optional)
+Most partners use client-side callbacks to know when a user has completed an engagement.  This is the recommended callback strategy, and should be sufficient for most use cases.  However, in some configurations, a client-side callback is not possible.  In such configurations, a server-side callback is useful.
+
+In order to leverage server-side callbacks, the partner supplies a callback URL to true[X] during the integration phase.  Upon a user successfully completing an engagement, true[X] will make a request to the partner's callback URL with information about the engagement.  This callback generally happens in real time, but may be delayed depending on current load.  The callback will include the following parameters:
+| Parameter | Type | Description |
+| ------------- | ------------- | ------------- |
+| `application_key` | string | The partner-specific application key provided by true[X]. |
+| `network_user_id` | string | The unique, partner-provided user identifier for the user who completed the ad. |
+| `currency_amount` | int | The amount of currency earned by completing the ad. |
+| `currency_label` | string | The label of the currency used (e.g. "coins"). |
+| `revenue` | decimal | The amount of revenue earned by the partner for this engagement. Values can have up to 8 decimal places. |
+| `placement_hash` | string | The identifier hash of the placement from which this engagement originated. |
+| `campaign_name` | string | The name of the campaign completed in this engagement. |
+| `campaign_id` | string | The unique identifier of the campaign completed in this engagement. |
+| `creative_name` | string | The name of the creative completed in this engagement. |
+| `creative_id` | string | The unique identifier of the creative completed in this engagement. |
+| `engagement_id` | string | The unique, true[X]-generated identifier for this engagement.  If a non-unique engagement_id is passed to the partner, the request should be ignored and return a failure code (see below) to avoid over-crediting a user. |
+| `sig` | string | The signature of the signed request.  See the [Callback Signing](#callback-signing) section below for details. |
+
+The partner should ensure that the callback URL provides the following response codes:
+- 0 – Recoverable failure (request will be retried)
+- 1 – Callback successfully processed
+- 2 – Invalid signature (this will notify true[X] for investigation)
+- 3 – Invalid user or duplicate engagement_id (request will not be retried)
+
+### Callback Signing
+In order to protect both true[X] and its publishers from request forgery, all engagement callbacks will be signed using the following algorithm:
+1. Put parameters in an array of `key=value` pairs.
+2. Order array of parameter pairs in alphabetical order by parameter key.
+3. Concatenate parameter pairs into a string.
+4. Append the partner-specific `application_secret` provided by true[X] to the string.
+5. Calculate a keyed-hash message authentication code (HMAC-SHA1) signature using the partner-specific `application_secret`.
+6. URL escape the signature before using it as a query argument.
+
+Sample signature generation using PHP:
+```php
+<?php
+$application_secret = 'XXXXXXXXXXXX';
+$args = array(
+  'application_key' => 'XXXXXXXXXXXXXXXX',
+  'network_user_id' => 'XXXXXXXXXX',
+  'currency_amount' => 'XXX',
+  'currency_label' => 'XXXX',
+  'revenue' => 'XXX.XXXXXXXX',
+  'placement_hash' => 'XXXXXXXXXX',
+  'creative_name' => 'XXXXXXXXX',
+  'creative_id' => 'XXXXXXXXX',
+  'engagement_id' => 'XXX'); // Arguments used in the request
+ksort($args); // Sort arguments alphabetically
+
+$base_str = '';
+foreach ($args as $key => $value) {
+  $base_str .= $key . '=' . $value; // Note: there is no separator
+}
+$base_str .= $secret;
+$sig = base64_encode(hash_hmac('sha1', $base_str, $secret, true));
+?>
 ```


### PR DESCRIPTION
The WSAPI docs were missing information on how to properly use prepareActivity in the client to add client-side callbacks and handlers to an ad received from the WSAPI

Also added reporting API docs